### PR TITLE
Compute CoW Swap domain separator

### DIFF
--- a/src/libraries/CoWSwapEip712.sol
+++ b/src/libraries/CoWSwapEip712.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+/// @title CoW Swap EIP-712 Encoding Library
+/// @author CoW Swap Developers
+/// @dev The code in this contract was largely taken from:
+/// <https://raw.githubusercontent.com/cowprotocol/contracts/v1.0.0/src/contracts/mixins/GPv2Signing.sol>
+library CoWSwapEip712 {
+    /// @dev The EIP-712 domain type hash used for computing the domain separator.
+    bytes32 private constant DOMAIN_TYPE_HASH =
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+
+    /// @dev The EIP-712 domain name used for computing the domain separator.
+    bytes32 private constant DOMAIN_NAME = keccak256("Gnosis Protocol");
+
+    /// @dev The EIP-712 domain version used for computing the domain separator.
+    bytes32 private constant DOMAIN_VERSION = keccak256("v2");
+
+    /// @dev Computes the EIP-712 domain separator of the CoW Swap settlement contract on the current network.
+    ///
+    /// @param cowSwapAddress The address of the CoW Swap settlement contract for which to compute the domain separator.
+    /// Note that there are no checks to verify that the input address points to an actual contract.
+    /// @return The domain separator of the settlement contract for the input address as computed by the settlement
+    /// contract internally.
+    function domainSeparator(address cowSwapAddress)
+        internal
+        view
+        returns (bytes32)
+    {
+        // NOTE: Currently, the only way to get the chain ID in solidity is using assembly.
+        uint256 chainId;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            chainId := chainid()
+        }
+
+        return
+            keccak256(
+                abi.encode(
+                    DOMAIN_TYPE_HASH,
+                    DOMAIN_NAME,
+                    DOMAIN_VERSION,
+                    chainId,
+                    cowSwapAddress
+                )
+            );
+    }
+}

--- a/test/CoWSwapEip712Eip712.t.sol
+++ b/test/CoWSwapEip712Eip712.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "forge-std/Test.sol";
+import "../src/libraries/CoWSwapEip712.sol";
+import "./Constants.sol";
+
+contract TestCoWSwapEip712 is Test {
+    function testDomainSeparator() public {
+        // Computed in the CoW Swap contract repo as:
+        // > ethers.utils._TypedDataEncoder.hashDomain(domain(31337, "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"))
+        bytes32 anvilDomainSeparator = 0x28dc932d67cd79da82085f7fbb19d7c88f84894397b07917354176f60f0096d4;
+
+        assertEq(
+            CoWSwapEip712.domainSeparator(Constants.COWSWAP_ADDRESS),
+            anvilDomainSeparator
+        );
+    }
+
+    function testConsistentMainnetDomainSeparator() public {
+        // https://etherscan.io/address/0x9008d19f58aabd9ed0d60971565aa8510560ab41#readContract
+        bytes32 mainnetDomainSeparator = 0xc078f884a2676e1345748b1feace7b0abee5d00ecadb6e574dcdd109a63e8943;
+
+        vm.chainId(1);
+        assertEq(
+            CoWSwapEip712.domainSeparator(Constants.COWSWAP_ADDRESS),
+            mainnetDomainSeparator
+        );
+    }
+
+    function testConsistentGoerliDomainSeparator() public {
+        // https://goerli.etherscan.io/address/0x9008d19f58aabd9ed0d60971565aa8510560ab41#readContract
+        bytes32 goerliDomainSeparator = 0xfb378b35457022ecc5709ae5dafad9393c1387ae6d8ce24913a0c969074c07fb;
+
+        vm.chainId(5);
+        assertEq(
+            CoWSwapEip712.domainSeparator(Constants.COWSWAP_ADDRESS),
+            goerliDomainSeparator
+        );
+    }
+}

--- a/test/Constants.sol
+++ b/test/Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+library Constants {
+    /// @dev Deterministic address of CoW Swap's settlement contract.
+    address public constant COWSWAP_ADDRESS =
+        0x9008D19f58AAbD9eD0D60971565AA8510560ab41;
+}


### PR DESCRIPTION
Adds code that compute the domain separator for the settlement contract.

To @josojo: this was copied from https://github.com/fedgiac/eth-flow-contracts/pull/1 and you already reviewed it.

### Test plan

New unit tests.
