### PR TITLE
Add order creation event emitter

### DIFF
--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -16,7 +16,7 @@ interface ICoWSwapOnchainOrders {
     struct OnchainSignature {
         /// @dev The signing scheme used by the signature data.
         OnchainSigningScheme scheme;
-        /// @dev The actual data used as an order signature.
+        /// @dev The data used as an order signature.
         bytes data;
     }
 
@@ -25,8 +25,8 @@ interface ICoWSwapOnchainOrders {
     /// @param sender The user who triggered the creation of the order. Note that this address does *not* need to be
     /// the actual owner of the order and does not need to be related to the order or signature in any way.
     /// For example, if a smart contract creates orders on behalf of the user, then the sender would be the user who
-    /// triggered the creation of the order, while the actual owner of the order would be the smart contract that
-    /// created it.
+    /// triggers the creation of the order, while the actual owner of the order would be the smart contract that
+    /// creates it.
     /// @param order Information on the order that is created in this transacion. The order is expected to be a valid
     /// order for the CoW Swap settlement contract and contain all information needed to settle it in a batch.
     /// @param signature The signature that can be used to verify the newly created order. Note that it is always

--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "../vendored/GPv2Order.sol";
+
+/// @title CoW Swap Onchain Order Creator Interface
+/// @author CoW Swap Developers
+interface ICoWSwapOnchainOrders {
+    /// @dev List of signature schemes that are supported by this contract to create orders onchain.
+    enum OnchainSigningScheme {
+        Eip1271,
+        PreSign
+    }
+
+    /// @dev Struct containing information on the signign scheme used plus the corresponding signature.
+    struct OnchainSignature {
+        /// @dev The signing scheme used by the signature data.
+        OnchainSigningScheme scheme;
+        /// @dev The actual data used as an order signature.
+        bytes data;
+    }
+
+    /// @dev Event emitted to broadcast an order onchain.
+    ///
+    /// @param sender The user who triggered the creation of the order. Note that this address does *not* need to be
+    /// the actual owner of the order and does not need to be related to the order or signature in any way.
+    /// For example, if a smart contract creates orders on behalf of the user, then the sender would be the user who
+    /// triggered the creation of the order, while the actual owner of the order would be the smart contract that
+    /// created it.
+    /// @param order Information on the order that is created in this transacion. The order is expected to be a valid
+    /// order for the CoW Swap settlement contract and contain all information needed to settle it in a batch.
+    /// @param signature The signature that can be used to verify the newly created order. Note that it is always
+    /// possible to recover the owner of the order from a valid signature.
+    /// @param data Any extra data that should be passed along with the order. This will be used by the services that
+    /// collects onchain orders and no specific encoding is enforced on this field. It is supposed to encode extra
+    /// information that is not included in the order data so that it can be passed along when decoding an onchain
+    /// order. As an example, a contract that creates orders on behalf of a user could set a different expiration date
+    /// than the one specified in the order.
+    event OrderPlacement(
+        address indexed sender,
+        GPv2Order.Data order,
+        OnchainSignature signature,
+        bytes data
+    );
+}

--- a/src/mixins/CoWSwapOnchainOrders.sol
+++ b/src/mixins/CoWSwapOnchainOrders.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "../vendored/GPv2Order.sol";
+import "../interfaces/ICoWSwapOnchainOrders.sol";
+import "../libraries/CoWSwapEip712.sol";
+
+/// @title CoW Swap Onchain Order Creator Event Emitter
+/// @author CoW Swap Developers
+contract CoWSwapOnchainOrders is ICoWSwapOnchainOrders {
+    using GPv2Order for GPv2Order.Data;
+    using GPv2Order for bytes;
+
+    /// @dev The domain separator for the CoW Swap settlement contract.
+    bytes32 internal immutable cowSwapDomainSeparator;
+
+    /// @param settlementContractAddress The address of CoW Swap's settlement contract on the chain where this contract
+    /// is deployed.
+    constructor(address settlementContractAddress) {
+        cowSwapDomainSeparator = CoWSwapEip712.domainSeparator(
+            settlementContractAddress
+        );
+    }
+
+    /// @dev Emits an event with all information needed to execute an order onchain and returns the corresponding order
+    /// hash.
+    ///
+    /// See [`ICoWSwapOnchainOrders.OrderPlacement`] for details on the meaning of each parameter.
+    /// @return The EIP-712 hash of the order data as computed by the CoW Swap settlement contract.
+    function placeOrder(
+        address sender,
+        GPv2Order.Data memory order,
+        OnchainSignature memory signature,
+        bytes memory data
+    ) internal returns (bytes32) {
+        emit OrderPlacement(sender, order, signature, data);
+        return order.hash(cowSwapDomainSeparator);
+    }
+}

--- a/src/mixins/CoWSwapOnchainOrders.sol
+++ b/src/mixins/CoWSwapOnchainOrders.sol
@@ -27,7 +27,7 @@ contract CoWSwapOnchainOrders is ICoWSwapOnchainOrders {
     ///
     /// See [`ICoWSwapOnchainOrders.OrderPlacement`] for details on the meaning of each parameter.
     /// @return The EIP-712 hash of the order data as computed by the CoW Swap settlement contract.
-    function placeOrder(
+    function broadcastOrder(
         address sender,
         GPv2Order.Data memory order,
         OnchainSignature memory signature,

--- a/src/vendored/GPv2Order.sol
+++ b/src/vendored/GPv2Order.sol
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+// Vendored from GPv2 contracts v1.1.2, see:
+// <https://raw.githubusercontent.com/cowprotocol/contracts/v1.0.0/src/contracts/libraries/GPv2Order.sol>
+// The following changes were made:
+// - Bumped up Solidity version.
+// - Vendored imports.
+// - Made some constants publicly available.
+
+pragma solidity ^0.8;
+
+import "./IERC20.sol";
+
+/// @title Gnosis Protocol v2 Order Library
+/// @author Gnosis Developers
+library GPv2Order {
+    /// @dev The complete data for a Gnosis Protocol order. This struct contains
+    /// all order parameters that are signed for submitting to GP.
+    struct Data {
+        IERC20 sellToken;
+        IERC20 buyToken;
+        address receiver;
+        uint256 sellAmount;
+        uint256 buyAmount;
+        uint32 validTo;
+        bytes32 appData;
+        uint256 feeAmount;
+        bytes32 kind;
+        bool partiallyFillable;
+        bytes32 sellTokenBalance;
+        bytes32 buyTokenBalance;
+    }
+
+    /// @dev The order EIP-712 type hash for the [`GPv2Order.Data`] struct.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256(
+    ///     "Order(" +
+    ///         "address sellToken," +
+    ///         "address buyToken," +
+    ///         "address receiver," +
+    ///         "uint256 sellAmount," +
+    ///         "uint256 buyAmount," +
+    ///         "uint32 validTo," +
+    ///         "bytes32 appData," +
+    ///         "uint256 feeAmount," +
+    ///         "string kind," +
+    ///         "bool partiallyFillable" +
+    ///         "string sellTokenBalance" +
+    ///         "string buyTokenBalance" +
+    ///     ")"
+    /// )
+    /// ```
+    bytes32 public constant TYPE_HASH =
+        hex"d5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e489";
+
+    /// @dev The marker value for a sell order for computing the order struct
+    /// hash. This allows the EIP-712 compatible wallets to display a
+    /// descriptive string for the order kind (instead of 0 or 1).
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("sell")
+    /// ```
+    bytes32 public constant KIND_SELL =
+        hex"f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775";
+
+    /// @dev The OrderKind marker value for a buy order for computing the order
+    /// struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("buy")
+    /// ```
+    bytes32 public constant KIND_BUY =
+        hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc";
+
+    /// @dev The TokenBalance marker value for using direct ERC20 balances for
+    /// computing the order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("erc20")
+    /// ```
+    bytes32 public constant BALANCE_ERC20 =
+        hex"5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9";
+
+    /// @dev The TokenBalance marker value for using Balancer Vault external
+    /// balances (in order to re-use Vault ERC20 approvals) for computing the
+    /// order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("external")
+    /// ```
+    bytes32 public constant BALANCE_EXTERNAL =
+        hex"abee3b73373acd583a130924aad6dc38cfdc44ba0555ba94ce2ff63980ea0632";
+
+    /// @dev The TokenBalance marker value for using Balancer Vault internal
+    /// balances for computing the order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("internal")
+    /// ```
+    bytes32 public constant BALANCE_INTERNAL =
+        hex"4ac99ace14ee0a5ef932dc609df0943ab7ac16b7583634612f8dc35a4289a6ce";
+
+    /// @dev Marker address used to indicate that the receiver of the trade
+    /// proceeds should the owner of the order.
+    ///
+    /// This is chosen to be `address(0)` for gas efficiency as it is expected
+    /// to be the most common case.
+    address public constant RECEIVER_SAME_AS_OWNER = address(0);
+
+    /// @dev The byte length of an order unique identifier.
+    uint256 public constant UID_LENGTH = 56;
+
+    /// @dev Returns the actual receiver for an order. This function checks
+    /// whether or not the [`receiver`] field uses the marker value to indicate
+    /// it is the same as the order owner.
+    ///
+    /// @return receiver The actual receiver of trade proceeds.
+    function actualReceiver(Data memory order, address owner)
+        internal
+        pure
+        returns (address receiver)
+    {
+        if (order.receiver == RECEIVER_SAME_AS_OWNER) {
+            receiver = owner;
+        } else {
+            receiver = order.receiver;
+        }
+    }
+
+    /// @dev Return the EIP-712 signing hash for the specified order.
+    ///
+    /// @param order The order to compute the EIP-712 signing hash for.
+    /// @param domainSeparator The EIP-712 domain separator to use.
+    /// @return orderDigest The 32 byte EIP-712 struct hash.
+    function hash(Data memory order, bytes32 domainSeparator)
+        internal
+        pure
+        returns (bytes32 orderDigest)
+    {
+        bytes32 structHash;
+
+        // NOTE: Compute the EIP-712 order struct hash in place. As suggested
+        // in the EIP proposal, noting that the order struct has 10 fields, and
+        // including the type hash `(12 + 1) * 32 = 416` bytes to hash.
+        // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#rationale-for-encodedata>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let dataStart := sub(order, 32)
+            let temp := mload(dataStart)
+            mstore(dataStart, TYPE_HASH)
+            structHash := keccak256(dataStart, 416)
+            mstore(dataStart, temp)
+        }
+
+        // NOTE: Now that we have the struct hash, compute the EIP-712 signing
+        // hash using scratch memory past the free memory pointer. The signing
+        // hash is computed from `"\x19\x01" || domainSeparator || structHash`.
+        // <https://docs.soliditylang.org/en/v0.8.16/internals/layout_in_memory.html#layout-in-memory>
+        // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#specification>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let freeMemoryPointer := mload(0x40)
+            mstore(freeMemoryPointer, "\x19\x01")
+            mstore(add(freeMemoryPointer, 2), domainSeparator)
+            mstore(add(freeMemoryPointer, 34), structHash)
+            orderDigest := keccak256(freeMemoryPointer, 66)
+        }
+    }
+
+    /// @dev Packs order UID parameters into the specified memory location. The
+    /// result is equivalent to `abi.encodePacked(...)` with the difference that
+    /// it allows re-using the memory for packing the order UID.
+    ///
+    /// This function reverts if the order UID buffer is not the correct size.
+    ///
+    /// @param orderUid The buffer pack the order UID parameters into.
+    /// @param orderDigest The EIP-712 struct digest derived from the order
+    /// parameters.
+    /// @param owner The address of the user who owns this order.
+    /// @param validTo The epoch time at which the order will stop being valid.
+    function packOrderUidParams(
+        bytes memory orderUid,
+        bytes32 orderDigest,
+        address owner,
+        uint32 validTo
+    ) internal pure {
+        require(orderUid.length == UID_LENGTH, "GPv2: uid buffer overflow");
+
+        // NOTE: Write the order UID to the allocated memory buffer. The order
+        // parameters are written to memory in **reverse order** as memory
+        // operations write 32-bytes at a time and we want to use a packed
+        // encoding. This means, for example, that after writing the value of
+        // `owner` to bytes `20:52`, writing the `orderDigest` to bytes `0:32`
+        // will **overwrite** bytes `20:32`. This is desirable as addresses are
+        // only 20 bytes and `20:32` should be `0`s:
+        //
+        //        |           1111111111222222222233333333334444444444555555
+        //   byte | 01234567890123456789012345678901234567890123456789012345
+        // -------+---------------------------------------------------------
+        //  field | [.........orderDigest..........][......owner.......][vT]
+        // -------+---------------------------------------------------------
+        // mstore |                         [000000000000000000000000000.vT]
+        //        |                     [00000000000.......owner.......]
+        //        | [.........orderDigest..........]
+        //
+        // Additionally, since Solidity `bytes memory` are length prefixed,
+        // 32 needs to be added to all the offsets.
+        //
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(add(orderUid, 56), validTo)
+            mstore(add(orderUid, 52), owner)
+            mstore(add(orderUid, 32), orderDigest)
+        }
+    }
+
+    /// @dev Extracts specific order information from the standardized unique
+    /// order id of the protocol.
+    ///
+    /// @param orderUid The unique identifier used to represent an order in
+    /// the protocol. This uid is the packed concatenation of the order digest,
+    /// the validTo order parameter and the address of the user who created the
+    /// order. It is used by the user to interface with the contract directly,
+    /// and not by calls that are triggered by the solvers.
+    /// @return orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the user who owns this order.
+    /// @return validTo The epoch time at which the order will stop being valid.
+    function extractOrderUidParams(bytes calldata orderUid)
+        internal
+        pure
+        returns (
+            bytes32 orderDigest,
+            address owner,
+            uint32 validTo
+        )
+    {
+        require(orderUid.length == UID_LENGTH, "GPv2: invalid uid");
+
+        // Use assembly to efficiently decode packed calldata.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            orderDigest := calldataload(orderUid.offset)
+            owner := shr(96, calldataload(add(orderUid.offset, 32)))
+            validTo := shr(224, calldataload(add(orderUid.offset, 52)))
+        }
+    }
+}

--- a/src/vendored/IERC20.sol
+++ b/src/vendored/IERC20.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+// Vendored from OpenZeppelin Contracts v4.4.0, see:
+// <https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/v4.4.0/contracts/token/ERC20/IERC20.sol>
+
+// OpenZeppelin Contracts v4.4.0 (token/ERC20/IERC20.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount)
+        external
+        returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+}

--- a/test/CoWSwapEip712Eip712.t.sol
+++ b/test/CoWSwapEip712Eip712.t.sol
@@ -7,13 +7,9 @@ import "./Constants.sol";
 
 contract TestCoWSwapEip712 is Test {
     function testDomainSeparator() public {
-        // Computed in the CoW Swap contract repo as:
-        // > ethers.utils._TypedDataEncoder.hashDomain(domain(31337, "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"))
-        bytes32 anvilDomainSeparator = 0x28dc932d67cd79da82085f7fbb19d7c88f84894397b07917354176f60f0096d4;
-
         assertEq(
             CoWSwapEip712.domainSeparator(Constants.COWSWAP_ADDRESS),
-            anvilDomainSeparator
+            Constants.COWSWAP_TEST_DOMAIN_SEPARATOR
         );
     }
 

--- a/test/CoWSwapOnchainOrders.t.sol
+++ b/test/CoWSwapOnchainOrders.t.sol
@@ -55,7 +55,7 @@ contract TestCoWSwapOnchainOrders is Test, ICoWSwapOnchainOrders {
         bytes32 orderHash = 0x65e25f4dac20ef9e411ba2e6a5c6c2697ce004564ffeeb5fe8a3d9f6529974f5;
 
         assertEq(
-            onchainOrders.placeOrderPublic(
+            onchainOrders.broadcastOrderPublic(
                 address(42),
                 order,
                 ICoWSwapOnchainOrders.OnchainSignature(
@@ -86,6 +86,6 @@ contract TestCoWSwapOnchainOrders is Test, ICoWSwapOnchainOrders {
             signature,
             data
         );
-        onchainOrders.placeOrderPublic(sender, order, signature, data);
+        onchainOrders.broadcastOrderPublic(sender, order, signature, data);
     }
 }

--- a/test/CoWSwapOnchainOrders.t.sol
+++ b/test/CoWSwapOnchainOrders.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "forge-std/Test.sol";
+import "./CoWSwapOnchainOrders/CoWSwapOnchainOrdersExposed.sol";
+import "./Constants.sol";
+import "../src/vendored/GPv2Order.sol";
+import "../src/interfaces/ICoWSwapOnchainOrders.sol";
+
+// Note: inheriting the interface ICoWSwapOnchainOrders allows us to emit the event without redefining it again in this
+// contract.
+contract TestCoWSwapOnchainOrders is Test, ICoWSwapOnchainOrders {
+    CoWSwapOnchainOrdersExposed internal onchainOrders;
+
+    function setUp() public {
+        onchainOrders = new CoWSwapOnchainOrdersExposed(
+            Constants.COWSWAP_ADDRESS
+        );
+    }
+
+    function testDomainSeparator() public {
+        // Other tests generate test data based on this domain separator.
+        assertEq(
+            onchainOrders.cowSwapDomainSeparatorPublic(),
+            Constants.COWSWAP_TEST_DOMAIN_SEPARATOR
+        );
+    }
+
+    function dummyOrder() public pure returns (GPv2Order.Data memory) {
+        return
+            GPv2Order.Data(
+                IERC20(address(0x0101010101010101010101010101010101010101)), // IERC20 sellToken
+                IERC20(address(0x0202020202020202020202020202020202020202)), // IERC20 buyToken
+                address(address(0x0303030303030303030303030303030303030303)), // address receiver
+                42 ether, // uint256 sellAmount
+                1337e16, // uint256 buyAmount
+                0xffffffff, // uint32 validTo
+                bytes32(0), // bytes32 appData
+                1 ether, // uint256 feeAmount
+                GPv2Order.KIND_SELL, // bytes32 kind
+                false, // bool partiallyFillable
+                GPv2Order.BALANCE_ERC20, // bytes32 sellTokenBalance
+                GPv2Order.BALANCE_ERC20 // bytes32 buyTokenBalance
+            );
+    }
+
+    function testReturnedOrderHash() public {
+        // Note: the order data is the same used here:
+        // https://github.com/cowprotocol/contracts/blob/31b86ed0a882e669a3d6e2301bb432386204ecc5/test/GPv2Order.test.ts#L35-L46
+        GPv2Order.Data memory order = dummyOrder();
+        // Computed by running the test "computes EIP-712 order signing hash" in the contracts repo with two changes:
+        // 1. Replacing `domainSeparator` with the constant at Constants.COWSWAP_TEST_DOMAIN_SEPARATOR.
+        // 2. Replacing the expect line with `console.log(await orders.hashTest(encodeOrder(order), domainSeparator));`.
+        // https://github.com/cowprotocol/contracts/blob/31b86ed0a882e669a3d6e2301bb432386204ecc5/test/GPv2Order.test.ts#L31-L51
+        bytes32 orderHash = 0x65e25f4dac20ef9e411ba2e6a5c6c2697ce004564ffeeb5fe8a3d9f6529974f5;
+
+        assertEq(
+            onchainOrders.placeOrderPublic(
+                address(42),
+                order,
+                ICoWSwapOnchainOrders.OnchainSignature(
+                    ICoWSwapOnchainOrders.OnchainSigningScheme.Eip1271,
+                    hex"5ec1e7"
+                ),
+                hex"da7a"
+            ),
+            orderHash
+        );
+    }
+
+    function testEmitsEvent() public {
+        GPv2Order.Data memory order = dummyOrder();
+
+        address sender = address(42);
+        ICoWSwapOnchainOrders.OnchainSignature
+            memory signature = ICoWSwapOnchainOrders.OnchainSignature(
+                ICoWSwapOnchainOrders.OnchainSigningScheme.Eip1271,
+                hex"5ec1e7"
+            );
+        bytes memory data = hex"da7a";
+
+        vm.expectEmit(true, true, true, true, address(onchainOrders));
+        emit ICoWSwapOnchainOrders.OrderPlacement(
+            sender,
+            order,
+            signature,
+            data
+        );
+        onchainOrders.placeOrderPublic(sender, order, signature, data);
+    }
+}

--- a/test/CoWSwapOnchainOrders.t.sol
+++ b/test/CoWSwapOnchainOrders.t.sol
@@ -31,7 +31,7 @@ contract TestCoWSwapOnchainOrders is Test, ICoWSwapOnchainOrders {
             GPv2Order.Data(
                 IERC20(address(0x0101010101010101010101010101010101010101)), // IERC20 sellToken
                 IERC20(address(0x0202020202020202020202020202020202020202)), // IERC20 buyToken
-                address(address(0x0303030303030303030303030303030303030303)), // address receiver
+                address(0x0303030303030303030303030303030303030303), // address receiver
                 42 ether, // uint256 sellAmount
                 1337e16, // uint256 buyAmount
                 0xffffffff, // uint32 validTo

--- a/test/CoWSwapOnchainOrders/CoWSwapOnchainOrdersExposed.sol
+++ b/test/CoWSwapOnchainOrders/CoWSwapOnchainOrdersExposed.sol
@@ -21,12 +21,12 @@ contract CoWSwapOnchainOrdersExposed is CoWSwapOnchainOrders {
 
     }
 
-    function placeOrderPublic(
+    function broadcastOrderPublic(
         address sender,
         GPv2Order.Data memory order,
         OnchainSignature memory signature,
         bytes memory data
     ) public returns (bytes32) {
-        return placeOrder(sender, order, signature, data);
+        return broadcastOrder(sender, order, signature, data);
     }
 }

--- a/test/CoWSwapOnchainOrders/CoWSwapOnchainOrdersExposed.sol
+++ b/test/CoWSwapOnchainOrders/CoWSwapOnchainOrdersExposed.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+import "../../src/mixins/CoWSwapOnchainOrders.sol";
+
+/// @dev Wrapper that exposes internal funcions of CoWSwapOnchainOrders.
+contract CoWSwapOnchainOrdersExposed is CoWSwapOnchainOrders {
+    using GPv2Order for GPv2Order.Data;
+    using GPv2Order for bytes;
+
+    function cowSwapDomainSeparatorPublic() public view returns (bytes32) {
+        return cowSwapDomainSeparator;
+    }
+
+    /// @param settlementContractAddress The address of CoW Swap's settlement contract on the chain where this contract
+    /// is deployed.
+    constructor(address settlementContractAddress)
+        CoWSwapOnchainOrders(settlementContractAddress)
+    // solhint-disable-next-line no-empty-blocks
+    {
+
+    }
+
+    function placeOrderPublic(
+        address sender,
+        GPv2Order.Data memory order,
+        OnchainSignature memory signature,
+        bytes memory data
+    ) public returns (bytes32) {
+        return placeOrder(sender, order, signature, data);
+    }
+}

--- a/test/Constants.sol
+++ b/test/Constants.sol
@@ -5,4 +5,9 @@ library Constants {
     /// @dev Deterministic address of CoW Swap's settlement contract.
     address public constant COWSWAP_ADDRESS =
         0x9008D19f58AAbD9eD0D60971565AA8510560ab41;
+
+    // Computed in the CoW Swap contract repo as:
+    // > ethers.utils._TypedDataEncoder.hashDomain(domain(31337, "0x9008D19f58AAbD9eD0D60971565AA8510560ab41"))
+    bytes32 public constant COWSWAP_TEST_DOMAIN_SEPARATOR =
+        0x28dc932d67cd79da82085f7fbb19d7c88f84894397b07917354176f60f0096d4;
 }


### PR DESCRIPTION
To @josojo: you already started reviewing the same PR [here](https://github.com/fedgiac/eth-flow-contracts/pull/2). I'm adding the comments from the review.

Adds a new contract that emits onchain all information needed to pick up and settle an order.

Note how I split the contract into an actual contract and an empty interface (except for some type and event definition).
This is done because testing that events are emitted in Foundry requires the testing contract to emit the same event. Separating the event in an interface makes the event accessible to the testing contract and doesn't require us to define the event twice.

### Test plan

New unit tests.

Also, verify the newly vendored contracts with the interfaces from the readme in their folder.