### PR TITLE
Add order deletion

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -108,15 +108,7 @@ contract CoWSwapEthFlow is CoWSwapOnchainOrders, ICoWSwapEthFlow {
         uint256 freedAmount = cowSwapOrder.sellAmount -
             cowSwapSettlement.filledAmount(orderUid);
 
-        // Using low level calls to perform the transfer avoids setting arbitrary limits to the amount of gas used in a
-        // call. The drawback is allowing reentrancy from this point in the contract. Note that the current order was
-        // already invalidated and cannot be claimed again. TODO: ensure that this is robust under order updates when
-        // implemented.
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = payable(orderData.owner).call{value: freedAmount}(
-            ""
-        );
-        if (!success) {
+        if (!payable(orderData.owner).send(freedAmount)) {
             revert EthTransferFailed();
         }
     }

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -13,6 +13,12 @@ interface ICoWSwapEthFlow {
     /// @dev Error thrown when trying to create an order without sending the expected amount of ETH to this contract.
     error IncorrectEthAmount();
 
+    /// @dev Error thrown if trying to delete an order while not allowed.
+    error NotAllowedToDeleteOrder(bytes32 orderHash);
+
+    /// @dev Error thrown when unsuccessfully sending ETH to an address.
+    error EthTransferFailed();
+
     /// @dev Function that creates and broadcasts an ETH flow order that sells native ETH. The order is paid for when
     /// the caller sends out the transaction. The caller takes ownership of the new order.
     ///
@@ -23,4 +29,10 @@ interface ICoWSwapEthFlow {
         external
         payable
         returns (bytes32 orderHash);
+
+    /// @dev Marks an existing ETH flow order as invalid and refunds the trader of all ETH that hasn't been traded yet.
+    /// Note that some parameters of the order are ignored, as for example the order expiration date and the quote id.
+    ///
+    /// @param order The order to be deleted.
+    function deleteOrder(EthFlowOrder.Data calldata order) external;
 }

--- a/src/interfaces/ICoWSwapSettlement.sol
+++ b/src/interfaces/ICoWSwapSettlement.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+/// @title CoW Swap Settlement Contract Interface
+/// @author CoW Swap Developers
+/// @dev This interface collects the functions of the CoW Swap settlement contract that are used by the ETH flow
+/// contract.
+interface ICoWSwapSettlement {
+    /// @dev Map each user order by UID to the amount that has been filled so
+    /// far. If this amount is larger than or equal to the amount traded in the
+    /// order (amount sold for sell orders, amount bought for buy orders) then
+    /// the order cannot be traded anymore. If the order is fill or kill, then
+    /// this value is only used to determine whether the order has already been
+    /// executed.
+    function filledAmount(bytes memory orderUid) external returns (uint256);
+}

--- a/src/libraries/EthFlowOrder.sol
+++ b/src/libraries/EthFlowOrder.sol
@@ -47,6 +47,10 @@ library EthFlowOrder {
     /// @dev An order that is owned by this address is an order that has not yet been assigned.
     address public constant NO_OWNER = address(0);
 
+    /// @dev An order that is owned by this address is an order that has been invalidated. Note that this address cannot
+    /// be directly used to create orders.
+    address public constant INVALIDATED_OWNER = address(type(uint160).max);
+
     /// @dev Error returned if the receiver of the ETH flow order is unspecified (`GPv2Order.RECEIVER_SAME_AS_OWNER`).
     error ReceiverMustBeSet();
 

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -1,20 +1,22 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
+// solhint-disable reason-string
+// solhint-disable not-rely-on-time
+
 import "forge-std/Test.sol";
 import "./Constants.sol";
 import "./CoWSwapEthFlow/CoWSwapEthFlowExposed.sol";
 import "./FillWithSameByte.sol";
+import "./Reverter.sol";
 import "../src/interfaces/ICoWSwapOnchainOrders.sol";
 
-contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
-    using EthFlowOrder for EthFlowOrder.Data;
-    using GPv2Order for GPv2Order.Data;
-
+contract EthFlowTestSetup is Test {
     CoWSwapEthFlowExposed internal ethFlow;
     IERC20 internal wrappedNativeToken =
         IERC20(0x1234567890123456789012345678901234567890);
-    address internal cowSwap = Constants.COWSWAP_ADDRESS;
+    ICoWSwapSettlement internal cowSwap =
+        ICoWSwapSettlement(Constants.COWSWAP_ADDRESS);
 
     function setUp() public {
         ethFlow = new CoWSwapEthFlowExposed(cowSwap, wrappedNativeToken);
@@ -30,6 +32,35 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
             Constants.COWSWAP_TEST_DOMAIN_SEPARATOR
         );
     }
+
+    // Unfortunately, even if the order mapping takes a bytes32 and returns a struct, Solidity interprets the output
+    // struct as a tuple instead. This wrapping function puts back the ouput into the same struct.
+    function ordersMapping(bytes32 orderHash)
+        internal
+        view
+        returns (EthFlowOrder.OnchainData memory)
+    {
+        (address owner, uint32 validTo) = ethFlow.orders(orderHash);
+        return EthFlowOrder.OnchainData(owner, validTo);
+    }
+
+    function mockOrderFilledAmount(bytes memory orderUid, uint256 amount)
+        public
+    {
+        vm.mockCall(
+            address(cowSwap),
+            abi.encodeWithSelector(
+                ICoWSwapSettlement.filledAmount.selector,
+                orderUid
+            ),
+            abi.encode(amount)
+        );
+    }
+}
+
+contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
+    using EthFlowOrder for EthFlowOrder.Data;
+    using GPv2Order for GPv2Order.Data;
 
     function testRevertOrderCreationIfNotEnoughEthSent() public {
         uint256 sellAmount = 1 ether;
@@ -181,5 +212,222 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
         );
         assertEq(ethFlowOwner, executor);
         assertEq(ethFlowValidTo, validTo);
+    }
+}
+
+contract OrderDeletion is EthFlowTestSetup {
+    using EthFlowOrder for EthFlowOrder.Data;
+    using GPv2Order for GPv2Order.Data;
+    using GPv2Order for bytes;
+
+    struct OrderDetails {
+        EthFlowOrder.Data data;
+        bytes32 hash;
+        bytes orderUid;
+    }
+
+    function orderDetails(EthFlowOrder.Data memory order)
+        internal
+        view
+        returns (OrderDetails memory)
+    {
+        bytes32 orderHash = order.toCoWSwapOrder(wrappedNativeToken).hash(
+            ethFlow.cowSwapDomainSeparatorPublic()
+        );
+        bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
+        orderUid.packOrderUidParams(
+            orderHash,
+            address(ethFlow),
+            type(uint32).max
+        );
+        return OrderDetails(order, orderHash, orderUid);
+    }
+
+    function dummyOrder() internal view returns (EthFlowOrder.Data memory) {
+        EthFlowOrder.Data memory order = EthFlowOrder.Data(
+            IERC20(FillWithSameByte.toAddress(0x01)),
+            FillWithSameByte.toAddress(0x02),
+            FillWithSameByte.toUint256(0x03),
+            FillWithSameByte.toUint256(0x04),
+            FillWithSameByte.toBytes32(0x05),
+            FillWithSameByte.toUint256(0x06),
+            FillWithSameByte.toUint32(0x07),
+            true,
+            FillWithSameByte.toUint64(0x08)
+        );
+        require(
+            order.validTo > block.timestamp,
+            "Dummy order is already expired, please update dummy expiration value"
+        );
+        return order;
+    }
+
+    function createOrderWithOwner(OrderDetails memory order, address owner)
+        public
+    {
+        vm.deal(owner, order.data.sellAmount);
+        vm.startPrank(owner);
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+        vm.stopPrank();
+    }
+
+    function testCanDeleteValidOrdersIfOwner() public {
+        address owner = address(0x424242);
+        EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
+        assertGt(ethFlowOrder.validTo, block.timestamp);
+        OrderDetails memory order = orderDetails(ethFlowOrder);
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.prank(owner);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+    }
+
+    function testCanDeleteExpiredOrdersIfNotOwner() public {
+        address owner = address(0x424242);
+        address executor = address(0x1337);
+        EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
+        ethFlowOrder.validTo = uint32(block.timestamp) - 1;
+        OrderDetails memory order = orderDetails(ethFlowOrder);
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.prank(executor);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+    }
+
+    function testCannotDeleteValidOrdersIfNotOwner() public {
+        address owner = address(0x424242);
+        address executor = address(0x1337);
+        EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
+        ethFlowOrder.validTo = uint32(block.timestamp) + 1;
+        OrderDetails memory order = orderDetails(ethFlowOrder);
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICoWSwapEthFlow.NotAllowedToDeleteOrder.selector,
+                order.hash
+            )
+        );
+        vm.prank(executor);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+    }
+
+    function testOrderDeletionSetsOrderAsInvalidated() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        assertEq(ordersMapping(order.hash).owner, owner);
+        vm.prank(owner);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+        assertEq(
+            ordersMapping(order.hash).owner,
+            EthFlowOrder.INVALIDATED_OWNER
+        );
+    }
+
+    function testOrderDeletionSendsEthBack() public {
+        // Using owner != executor to make certain that the ETH were not sent to msg.sender
+        address owner = address(0x424242);
+        address executor = address(0x1337);
+        EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
+        ethFlowOrder.validTo = uint32(block.timestamp) - 1;
+        OrderDetails memory order = orderDetails(ethFlowOrder);
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.prank(executor);
+        assertEq(owner.balance, 0);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+        assertEq(owner.balance, order.data.sellAmount);
+    }
+
+    function testOrderDeletionRevertsIfDeletingUninitializedOrder() public {
+        OrderDetails memory order = orderDetails(dummyOrder());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICoWSwapEthFlow.NotAllowedToDeleteOrder.selector,
+                order.hash
+            )
+        );
+        ethFlow.deleteOrder(order.data);
+    }
+
+    function testOrderDeletionRevertsIfDeletingOrderTwice() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.prank(owner);
+        ethFlow.deleteOrder(order.data);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICoWSwapEthFlow.NotAllowedToDeleteOrder.selector,
+                order.hash
+            )
+        );
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+    }
+
+    function testOrderDeletionForPartiallyFilledOrders() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+        createOrderWithOwner(order, owner);
+        uint256 filledAmount = 1337;
+        mockOrderFilledAmount(order.orderUid, filledAmount);
+
+        vm.prank(owner);
+        assertEq(owner.balance, 0);
+        ethFlow.deleteOrder(order.data);
+        assertEq(owner.balance, order.data.sellAmount - filledAmount);
+        vm.stopPrank();
+    }
+
+    function testOrderDeletionRevertsIfSendingEthFails() public {
+        address owner = address(new Reverter());
+        OrderDetails memory order = orderDetails(dummyOrder());
+        createOrderWithOwner(order, owner);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.prank(owner);
+        vm.expectRevert(ICoWSwapEthFlow.EthTransferFailed.selector);
+        ethFlow.deleteOrder(order.data);
+        vm.stopPrank();
+    }
+
+    function testCannotCreateSameOrderOnceDeleted() public {
+        address owner = address(0x424242);
+        EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
+        ethFlowOrder.validTo = uint32(block.timestamp) - 1;
+        OrderDetails memory order = orderDetails(ethFlowOrder);
+        mockOrderFilledAmount(order.orderUid, 0);
+
+        vm.deal(owner, order.data.sellAmount);
+        vm.startPrank(owner);
+
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+        ethFlow.deleteOrder(order.data);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ICoWSwapEthFlow.OrderIsAlreadyOwned.selector,
+                order.hash
+            )
+        );
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+
+        vm.stopPrank();
     }
 }

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -22,17 +22,6 @@ contract EthFlowTestSetup is Test {
         ethFlow = new CoWSwapEthFlowExposed(cowSwap, wrappedNativeToken);
     }
 
-    function testDeploymentParams() public {
-        assertEq(
-            address(ethFlow.wrappedNativeToken()),
-            address(wrappedNativeToken)
-        );
-        assertEq(
-            ethFlow.cowSwapDomainSeparatorPublic(),
-            Constants.COWSWAP_TEST_DOMAIN_SEPARATOR
-        );
-    }
-
     // Unfortunately, even if the order mapping takes a bytes32 and returns a struct, Solidity interprets the output
     // struct as a tuple instead. This wrapping function puts back the ouput into the same struct.
     function ordersMapping(bytes32 orderHash)
@@ -54,6 +43,19 @@ contract EthFlowTestSetup is Test {
                 orderUid
             ),
             abi.encode(amount)
+        );
+    }
+}
+
+contract TestDeployment is EthFlowTestSetup {
+    function testDeploymentParams() public {
+        assertEq(
+            address(ethFlow.wrappedNativeToken()),
+            address(wrappedNativeToken)
+        );
+        assertEq(
+            ethFlow.cowSwapDomainSeparatorPublic(),
+            Constants.COWSWAP_TEST_DOMAIN_SEPARATOR
         );
     }
 }

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -276,7 +276,6 @@ contract OrderDeletion is EthFlowTestSetup {
     function testCanDeleteValidOrdersIfOwner() public {
         address owner = address(0x424242);
         EthFlowOrder.Data memory ethFlowOrder = dummyOrder();
-        assertGt(ethFlowOrder.validTo, block.timestamp);
         OrderDetails memory order = orderDetails(ethFlowOrder);
         createOrderWithOwner(order, owner);
         mockOrderFilledAmount(order.orderUid, 0);

--- a/test/CoWSwapEthFlow/CoWSwapEthFlowExposed.sol
+++ b/test/CoWSwapEthFlow/CoWSwapEthFlowExposed.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8;
 
 import "../../src/CoWSwapEthFlow.sol";
+import "../../src/interfaces/ICoWSwapSettlement.sol";
 
 /// @dev Wrapper that exposes internal funcions of CoWSwapEthFlow.
 contract CoWSwapEthFlowExposed is CoWSwapEthFlow {
-    constructor(address settlementContractAddress, IERC20 weth)
+    constructor(ICoWSwapSettlement settlementContractAddress, IERC20 weth)
         CoWSwapEthFlow(settlementContractAddress, weth)
     // solhint-disable-next-line no-empty-blocks
     {

--- a/test/Reverter.sol
+++ b/test/Reverter.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+// It's not possible to mock reverting a function.
+// https://github.com/foundry-rs/foundry/issues/2740
+// This contract is a workaround to trigger a revert.
+contract Reverter {
+    receive() external payable {
+        revert("Mock revert");
+    }
+}


### PR DESCRIPTION
Adds a function for users to get back their ETH if the order wasn't executed.

For now we send ETH back to the user using transfers. This avoids reentrancy but adds a risk of users losing funds as they might not be able to cancel an order anymore.

Note that the conversion of ETH to WETH and vice-versa will be handled in a follow-up PR. 

Another unfortunate observation is that Foundry doesn't support mocking a revert from a contract.

### Test plan

New unit tests.