### PR TITLE
Add signature verification

### DIFF
--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -35,4 +35,20 @@ interface ICoWSwapEthFlow {
     ///
     /// @param order The order to be deleted.
     function deleteOrder(EthFlowOrder.Data calldata order) external;
+
+    /// @dev EIP1271-compliant onchain signature verification function.
+    /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an
+    /// EIP1271 signature is valid. As this contract has approved the vault relayer contract, a valid signature for an
+    /// order means that the order can be traded on CoW Swap.
+    ///
+    /// @param orderHash Hash of the order to be signed. This is the EIP-712 signing hash for the specified order as
+    /// defined in the CoW Swap settlement contract.
+    /// @param signature Signature byte array. This parameter is unused since as all information needed to verify if an
+    /// order is already available onchain.
+    /// @return magicValue Either the EIP-1271 "magic value" indicating success (0x1626ba7e) or a different value
+    /// indicating failure (0xffffffff).
+    function isValidSignature(bytes32 orderHash, bytes memory signature)
+        external
+        view
+        returns (bytes4 magicValue);
 }

--- a/src/vendored/GPv2EIP1271.sol
+++ b/src/vendored/GPv2EIP1271.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+// Vendored from GPv2 contracts v1.0.0, see:
+// <https://raw.githubusercontent.com/cowprotocol/contracts/main/src/contracts/interfaces/GPv2EIP1271.sol>
+// The following changes were made:
+// - Bumped up Solidity version.
+
+library GPv2EIP1271 {
+    /// @dev Value returned by a call to `isValidSignature` if the signature
+    /// was verified successfully. The value is defined in EIP-1271 as:
+    /// bytes4(keccak256("isValidSignature(bytes32,bytes)"))
+    bytes4 internal constant MAGICVALUE = 0x1626ba7e;
+}
+
+/// @title EIP1271 Interface
+/// @dev Standardized interface for an implementation of smart contract
+/// signatures as described in EIP-1271. The code that follows is identical to
+/// the code in the standard with the exception of formatting and syntax
+/// changes to adapt the code to our Solidity version.
+interface EIP1271Verifier {
+    /// @dev Should return whether the signature provided is valid for the
+    /// provided data
+    /// @param _hash      Hash of the data to be signed
+    /// @param _signature Signature byte array associated with _data
+    ///
+    /// MUST return the bytes4 magic value 0x1626ba7e when function passes.
+    /// MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for
+    /// solc > 0.5)
+    /// MUST allow external calls
+    ///
+    function isValidSignature(bytes32 _hash, bytes memory _signature)
+        external
+        view
+        returns (bytes4 magicValue);
+}

--- a/src/vendored/GPv2Order.sol
+++ b/src/vendored/GPv2Order.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-// Vendored from GPv2 contracts v1.1.2, see:
+// Vendored from GPv2 contracts v1.0.0, see:
 // <https://raw.githubusercontent.com/cowprotocol/contracts/v1.0.0/src/contracts/libraries/GPv2Order.sol>
 // The following changes were made:
 // - Bumped up Solidity version.

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -10,8 +10,19 @@ import "./CoWSwapEthFlow/CoWSwapEthFlowExposed.sol";
 import "./FillWithSameByte.sol";
 import "./Reverter.sol";
 import "../src/interfaces/ICoWSwapOnchainOrders.sol";
+import "../src/vendored/GPv2EIP1271.sol";
 
 contract EthFlowTestSetup is Test {
+    using EthFlowOrder for EthFlowOrder.Data;
+    using GPv2Order for GPv2Order.Data;
+    using GPv2Order for bytes;
+
+    struct OrderDetails {
+        EthFlowOrder.Data data;
+        bytes32 hash;
+        bytes orderUid;
+    }
+
     CoWSwapEthFlowExposed internal ethFlow;
     IERC20 internal wrappedNativeToken =
         IERC20(0x1234567890123456789012345678901234567890);
@@ -44,6 +55,23 @@ contract EthFlowTestSetup is Test {
             ),
             abi.encode(amount)
         );
+    }
+
+    function orderDetails(EthFlowOrder.Data memory order)
+        internal
+        view
+        returns (OrderDetails memory)
+    {
+        bytes32 orderHash = order.toCoWSwapOrder(wrappedNativeToken).hash(
+            ethFlow.cowSwapDomainSeparatorPublic()
+        );
+        bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
+        orderUid.packOrderUidParams(
+            orderHash,
+            address(ethFlow),
+            type(uint32).max
+        );
+        return OrderDetails(order, orderHash, orderUid);
     }
 }
 
@@ -214,33 +242,6 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
 }
 
 contract OrderDeletion is EthFlowTestSetup {
-    using EthFlowOrder for EthFlowOrder.Data;
-    using GPv2Order for GPv2Order.Data;
-    using GPv2Order for bytes;
-
-    struct OrderDetails {
-        EthFlowOrder.Data data;
-        bytes32 hash;
-        bytes orderUid;
-    }
-
-    function orderDetails(EthFlowOrder.Data memory order)
-        internal
-        view
-        returns (OrderDetails memory)
-    {
-        bytes32 orderHash = order.toCoWSwapOrder(wrappedNativeToken).hash(
-            ethFlow.cowSwapDomainSeparatorPublic()
-        );
-        bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
-        orderUid.packOrderUidParams(
-            orderHash,
-            address(ethFlow),
-            type(uint32).max
-        );
-        return OrderDetails(order, orderHash, orderUid);
-    }
-
     function dummyOrder() internal view returns (EthFlowOrder.Data memory) {
         EthFlowOrder.Data memory order = EthFlowOrder.Data(
             IERC20(FillWithSameByte.toAddress(0x01)),
@@ -419,5 +420,81 @@ contract OrderDeletion is EthFlowTestSetup {
         ethFlow.createOrder{value: order.data.sellAmount}(order.data);
 
         vm.stopPrank();
+    }
+}
+
+contract SignatureVerification is EthFlowTestSetup {
+    bytes4 internal constant BAD_SIGNATURE = 0xffffffff;
+
+    function dummyOrder() internal view returns (EthFlowOrder.Data memory) {
+        EthFlowOrder.Data memory order = EthFlowOrder.Data(
+            IERC20(FillWithSameByte.toAddress(0x11)),
+            FillWithSameByte.toAddress(0x12),
+            FillWithSameByte.toUint256(0x13),
+            FillWithSameByte.toUint256(0x14),
+            FillWithSameByte.toBytes32(0x15),
+            FillWithSameByte.toUint256(0x16),
+            FillWithSameByte.toUint32(0x17),
+            true,
+            FillWithSameByte.toUint64(0x18)
+        );
+        require(
+            order.validTo > block.timestamp,
+            "Dummy order is already expired, please update dummy expiration value"
+        );
+        return order;
+    }
+
+    function testBadSignatureIfOrderWasNotCreatedYet() public {
+        OrderDetails memory order = orderDetails(dummyOrder());
+
+        assertEq(ethFlow.isValidSignature(order.hash, ""), BAD_SIGNATURE);
+    }
+
+    function testGoodSignatureIfOrderIsValid() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+        assertGt(order.data.validTo, block.timestamp);
+
+        vm.deal(owner, order.data.sellAmount);
+        vm.prank(owner);
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+
+        assertEq(
+            ethFlow.isValidSignature(order.hash, ""),
+            GPv2EIP1271.MAGICVALUE
+        );
+    }
+
+    function testBadSignatureIfOrderIsExpired() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+        assertGt(order.data.validTo, block.timestamp);
+
+        vm.deal(owner, order.data.sellAmount);
+        vm.prank(owner);
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+
+        vm.warp(order.data.validTo + 1);
+        assertLt(order.data.validTo, block.timestamp);
+
+        assertEq(ethFlow.isValidSignature(order.hash, ""), BAD_SIGNATURE);
+    }
+
+    function testBadSignatureIfOrderWasDeleted() public {
+        address owner = address(0x424242);
+        OrderDetails memory order = orderDetails(dummyOrder());
+
+        vm.deal(owner, order.data.sellAmount);
+        vm.startPrank(owner);
+
+        ethFlow.createOrder{value: order.data.sellAmount}(order.data);
+        mockOrderFilledAmount(order.orderUid, 0);
+        ethFlow.deleteOrder(order.data);
+
+        vm.stopPrank();
+
+        assertGt(order.data.validTo, block.timestamp); // Ascertain that failure is not caused by an expired order.
+        assertEq(ethFlow.isValidSignature(order.hash, ""), BAD_SIGNATURE);
     }
 }


### PR DESCRIPTION
Adds the signature verification function for the eth flow.

Note that the function is simpler than described in the specification as no signature is needed.
(Previously, a signature was required to relay extra information on the order that wasn't available onchain: the `orders` mapping was a hash of its components and the components were passed through the signature and verified against the onchain hash.)

### Test plan

New unit tests.