### PR TITLE
Use int64 for quoteId

### DIFF
--- a/src/libraries/EthFlowOrder.sol
+++ b/src/libraries/EthFlowOrder.sol
@@ -41,7 +41,7 @@ library EthFlowOrder {
         /// @dev quoteId The quote id obtained from the CoW Swap API to lock in the current price. It is not directly
         /// used by any onchain component but is part of the information emitted onchain on order creation and may be
         /// required for an order to be automatically picked up by the CoW Swap orderbook.
-        uint64 quoteId;
+        int64 quoteId;
     }
 
     /// @dev An order that is owned by this address is an order that has not yet been assigned.

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -251,7 +251,7 @@ contract OrderDeletion is EthFlowTestSetup {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toUint64(0x08)
+            FillWithSameByte.toInt64(0x08)
         );
         require(
             order.validTo > block.timestamp,

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -61,7 +61,7 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toUint64(0x08)
+            FillWithSameByte.toInt64(0x08)
         );
         assertEq(order.sellAmount, sellAmount);
 
@@ -100,7 +100,7 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toUint64(0x08)
+            FillWithSameByte.toInt64(0x08)
         );
         assertEq(order.sellAmount, sellAmount);
 
@@ -114,7 +114,7 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
     function testOrderCreationEventHasExpectedParams() public {
         uint256 sellAmount = 42 ether;
         uint32 validTo = FillWithSameByte.toUint32(0x01);
-        uint64 quoteId = 1337;
+        int64 quoteId = 1337;
         EthFlowOrder.Data memory order = EthFlowOrder.Data(
             IERC20(FillWithSameByte.toAddress(0x02)),
             FillWithSameByte.toAddress(0x03),
@@ -161,7 +161,7 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
             FillWithSameByte.toUint256(0x06),
             validTo,
             true,
-            FillWithSameByte.toUint64(0x07)
+            FillWithSameByte.toInt64(0x07)
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.validTo, validTo);

--- a/test/EthFlowOrder.t.sol
+++ b/test/EthFlowOrder.t.sol
@@ -21,7 +21,7 @@ contract TestCoWSwapOnchainOrders is Test {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toUint64(0x08)
+            FillWithSameByte.toInt64(0x08)
         );
         IERC20 wrappedNativeToken = IERC20(FillWithSameByte.toAddress(0x42));
 
@@ -59,7 +59,7 @@ contract TestCoWSwapOnchainOrders is Test {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toUint32(0x08)
+            FillWithSameByte.toInt64(0x08)
         );
         assertEq(ethFlowOrder.receiver, GPv2Order.RECEIVER_SAME_AS_OWNER);
 

--- a/test/FillWithSameByte.sol
+++ b/test/FillWithSameByte.sol
@@ -10,12 +10,12 @@ library FillWithSameByte {
         return bytes32(repeatByte(b, 32));
     }
 
-    function toUint32(uint8 b) public pure returns (uint32) {
-        return uint32(repeatByte(b, 4));
+    function toInt64(uint8 b) public pure returns (int64) {
+        return int64(int256(repeatByte(b, 8)));
     }
 
-    function toUint64(uint8 b) public pure returns (uint64) {
-        return uint64(repeatByte(b, 8));
+    function toUint32(uint8 b) public pure returns (uint32) {
+        return uint32(repeatByte(b, 4));
     }
 
     function toUint256(uint8 b) public pure returns (uint256) {


### PR DESCRIPTION
`quoteId` is specified in the API and is a 64-bit _signed_ integer. 

This PR makes the parameter in the contract consistent with the type in the API.

### Test plan

Existing unit tests.