### PR TITLE
Switch place of quoteId and validTo in event data

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -51,8 +51,8 @@ contract CoWSwapEthFlow is CoWSwapOnchainOrders, ICoWSwapEthFlow {
 
         // The data event field includes extra information needed to settle orders with the CoW Swap API.
         bytes memory data = abi.encodePacked(
-            onchainData.validTo,
-            order.quoteId
+            order.quoteId,
+            onchainData.validTo
         );
 
         orderHash = broadcastOrder(

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -143,7 +143,7 @@ contract TestCoWSwapEthFlow is Test, ICoWSwapOnchainOrders {
             executor,
             order.toCoWSwapOrder(wrappedNativeToken),
             signature,
-            abi.encodePacked(validTo, quoteId)
+            abi.encodePacked(quoteId, validTo)
         );
         ethFlow.createOrder{value: sellAmount}(order);
         vm.stopPrank();


### PR DESCRIPTION
We discussed how event data is encoded for all contracts that emit `OrderPlacement` events. An option was to assume that `quoteId` was always encoded in the same position of `data`.
The most natural place for `quoteId` is then the first bytes of `data`, so that no padding is needed if a contract has no `validTo` and nothing to fit in these four bytes.

This change doesn't impact the functionality of this contract.

### Test plan

Modified unit test.