### PR TITLE
Use only internal library functions

### DIFF
--- a/src/libraries/EthFlowOrder.sol
+++ b/src/libraries/EthFlowOrder.sol
@@ -45,11 +45,11 @@ library EthFlowOrder {
     }
 
     /// @dev An order that is owned by this address is an order that has not yet been assigned.
-    address public constant NO_OWNER = address(0);
+    address internal constant NO_OWNER = address(0);
 
     /// @dev An order that is owned by this address is an order that has been invalidated. Note that this address cannot
     /// be directly used to create orders.
-    address public constant INVALIDATED_OWNER = address(type(uint160).max);
+    address internal constant INVALIDATED_OWNER = address(type(uint160).max);
 
     /// @dev Error returned if the receiver of the ETH flow order is unspecified (`GPv2Order.RECEIVER_SAME_AS_OWNER`).
     error ReceiverMustBeSet();
@@ -60,8 +60,8 @@ library EthFlowOrder {
     /// @param wrappedNativeToken The address of the wrapped native token for the current network (e.g., WETH for
     /// Ethereum mainet).
     /// @return The CoW Swap order data that represents the user order in the ETH flow contract.
-    function toCoWSwapOrder(Data calldata order, IERC20 wrappedNativeToken)
-        public
+    function toCoWSwapOrder(Data memory order, IERC20 wrappedNativeToken)
+        internal
         pure
         returns (GPv2Order.Data memory)
     {

--- a/src/vendored/GPv2Order.sol
+++ b/src/vendored/GPv2Order.sol
@@ -5,7 +5,6 @@
 // The following changes were made:
 // - Bumped up Solidity version.
 // - Vendored imports.
-// - Made some constants publicly available.
 
 pragma solidity ^0.8;
 
@@ -52,7 +51,7 @@ library GPv2Order {
     ///     ")"
     /// )
     /// ```
-    bytes32 public constant TYPE_HASH =
+    bytes32 internal constant TYPE_HASH =
         hex"d5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e489";
 
     /// @dev The marker value for a sell order for computing the order struct
@@ -63,7 +62,7 @@ library GPv2Order {
     /// ```
     /// keccak256("sell")
     /// ```
-    bytes32 public constant KIND_SELL =
+    bytes32 internal constant KIND_SELL =
         hex"f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775";
 
     /// @dev The OrderKind marker value for a buy order for computing the order
@@ -73,7 +72,7 @@ library GPv2Order {
     /// ```
     /// keccak256("buy")
     /// ```
-    bytes32 public constant KIND_BUY =
+    bytes32 internal constant KIND_BUY =
         hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc";
 
     /// @dev The TokenBalance marker value for using direct ERC20 balances for
@@ -83,7 +82,7 @@ library GPv2Order {
     /// ```
     /// keccak256("erc20")
     /// ```
-    bytes32 public constant BALANCE_ERC20 =
+    bytes32 internal constant BALANCE_ERC20 =
         hex"5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9";
 
     /// @dev The TokenBalance marker value for using Balancer Vault external
@@ -94,7 +93,7 @@ library GPv2Order {
     /// ```
     /// keccak256("external")
     /// ```
-    bytes32 public constant BALANCE_EXTERNAL =
+    bytes32 internal constant BALANCE_EXTERNAL =
         hex"abee3b73373acd583a130924aad6dc38cfdc44ba0555ba94ce2ff63980ea0632";
 
     /// @dev The TokenBalance marker value for using Balancer Vault internal
@@ -104,7 +103,7 @@ library GPv2Order {
     /// ```
     /// keccak256("internal")
     /// ```
-    bytes32 public constant BALANCE_INTERNAL =
+    bytes32 internal constant BALANCE_INTERNAL =
         hex"4ac99ace14ee0a5ef932dc609df0943ab7ac16b7583634612f8dc35a4289a6ce";
 
     /// @dev Marker address used to indicate that the receiver of the trade
@@ -112,10 +111,10 @@ library GPv2Order {
     ///
     /// This is chosen to be `address(0)` for gas efficiency as it is expected
     /// to be the most common case.
-    address public constant RECEIVER_SAME_AS_OWNER = address(0);
+    address internal constant RECEIVER_SAME_AS_OWNER = address(0);
 
     /// @dev The byte length of an order unique identifier.
-    uint256 public constant UID_LENGTH = 56;
+    uint256 internal constant UID_LENGTH = 56;
 
     /// @dev Returns the actual receiver for an order. This function checks
     /// whether or not the [`receiver`] field uses the marker value to indicate


### PR DESCRIPTION
Using public functions in [libraries](https://docs.soliditylang.org/en/v0.8.16/contracts.html?highlight=library#libraries) means that:
1. an extra library contract is deployed;
2. any call to a public function is a delegatecall to the external contract.

This is not desired behavior as it increase the overall execution cost. This is why in this PR all library functions are made `internal` instead.

It wasn't clear to me that extra contracts were being deployed until trying to deploy the contract with `forge create`, which fails because dynamic linking is not supported.

<details><summary>These changes lead to savings of up to 3k gas for creating and deleting orders. </summary>

The cost with the current changes is below.

```
│ Function Name                          ┆ min             ┆ avg   ┆ median ┆ max   ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ cowSwapDomainSeparatorPublic           ┆ 192             ┆ 192   ┆ 192    ┆ 192   ┆ 18      │
│ cowSwapDomainSeparatorPublic           ┆ 192             ┆ 192   ┆ 192    ┆ 192   ┆ 18      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ createOrder                            ┆ 308             ┆ 31643 ┆ 35859  ┆ 35859 ┆ 19      │
│ createOrder                            ┆ 308             ┆ 28630 ┆ 32678  ┆ 32678 ┆ 19      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ deleteOrder                            ┆ 5522            ┆ 28548 ┆ 38737  ┆ 38759 ┆ 12      │
│ deleteOrder                            ┆ 2335            ┆ 25361 ┆ 35550  ┆ 35572 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ isValidSignature                       ┆ 1027            ┆ 1537  ┆ 1060   ┆ 3001  ┆ 4       │
│ isValidSignature                       ┆ 1027            ┆ 1537  ┆ 1060   ┆ 3001  ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ orders                                 ┆ 528             ┆ 528   ┆ 528    ┆ 528   ┆ 3       │
│ orders                                 ┆ 528             ┆ 528   ┆ 528    ┆ 528   ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ wrappedNativeToken                     ┆ 227             ┆ 227   ┆ 227    ┆ 227   ┆ 1       │
│ wrappedNativeToken                     ┆ 227             ┆ 227   ┆ 227    ┆ 227   ┆ 1       │
```
</details>

### Test plan

Existing unit tests.

