### PR TITLE
Automaticallty generate artifacts

### DIFF
--- a/.github/scripts/artifacts.sh
+++ b/.github/scripts/artifacts.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Generates contract artifacts for the given tag (or `main` branch) and creates a new tagged commit with the newly
+# generated artifacts.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+main_branch="main"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <refs/tags/tag-name or 'refs/heads/$main_branch'>"
+  exit 1
+fi
+
+target_ref="$1"
+if [[ "$target_ref" != "refs/heads/$main_branch" ]] && ! [[ "$target_ref" =~ ^refs/tags/.* ]]; then
+  echo "Invalid git ref $target_ref" >&2
+  exit 1
+fi
+target_ref_short="${target_ref#refs/*/}"
+
+git_username="GitHub Actions"
+git_useremail="GitHub-Actions@cow.fi"
+
+if ! git config --get user.name &>/dev/null; then
+  git config user.name "$git_username"
+  git config user.email "$git_useremail"
+fi
+
+artifacts_tag="$target_ref_short-artifacts"
+
+git fetch origin "$target_ref"
+git checkout --detach "$target_ref"
+
+forge build -o artifacts
+
+git add artifacts
+git commit -m "Add artifacts for $target_ref"
+git tag -m "Artifacts for $target_ref" --end-of-options "$artifacts_tag"
+
+if [ "$target_ref" = "refs/heads/$main_branch" ]; then
+  # --force is used to overwrite the remote tag, if it exists.
+  # This is done to keep the artifacts always consistent with the main branch, history is not important.
+  git push --force origin "refs/tags/$artifacts_tag"
+else
+  # Check if artifact branch already exists. Don't delete old tagged artifacts to make sure that deleting tag history is
+  # intentional.
+  if git ls-remote --exit-code origin "refs/tags/$artifacts_tag" >/dev/null; then
+    echo "Error: the artifacts tag $artifacts_tag already exists on remote." >&2
+    echo "Existing artifacts will be preserved." >&2
+    echo "If deleting existing artifacts is intended, please delete both remote tags $target_ref and refs/tags/$artifacts_tag and then push again the same tag $target_ref to remote." >&2
+    exit 1
+  fi
+
+  git push origin "refs/tags/$artifacts_tag"
+fi

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,28 @@
+name: artifacts
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "**"
+      - "!**-artifacts"
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  artifacts:
+    name: Artifacts generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Generate artifacts and push as new tag
+        run: bash .github/scripts/artifacts.sh "$GITHUB_REF"

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,21 @@ yarn install
 forge build
 ```
 
+#### Build artifacts
+
+Build artifacts are automatically generated for every tagged version.
+
+A version of the code at tag `tag-name` with build artifacts included can ba found at tag `tag-name-artifacts`.
+Artifacts are stored in the folder `artifacts` in the root directory.
+
+The tag `master-artifacts` is kept up to date with the latest working version of current master and provides up-to-date artifacts.
+
+To manually generate the build artifacts, run:
+
+```sh
+forge build -o artifacts
+```
+
 ### Code formatting
 
 ```sh


### PR DESCRIPTION
Automatically generates build artifacts with GitHub actions.
Please review readme changes first for context and please let me know if anything is unclear.

This is done because the services need the artifacts from the contract in this repo from some sources. We used to deploy a package to NPM with the artifacts and a JS library, however this doesn't make much sense anymore since this is not a JS project.

### Test plan

I ran locally:

<details><summary>$ bash .github/scripts/artifacts.sh refs/heads/main</summary>

```
From github.com:cowprotocol/ethflowcontract
 * branch            main       -> FETCH_HEAD
HEAD is now at aa79574 Add signature verification (#8)
[⠊] Compiling...
[⠊] Compiling 25 files with 0.8.16
[⠢] Solc 0.8.16 finished in 3.95s
Compiler run successful
[detached HEAD 26c2c21] Add artifacts for refs/heads/main
 33 files changed, 570165 insertions(+)
 create mode 100644 artifacts/CoWSwapEip712.sol/CoWSwapEip712.json
 create mode 100644 artifacts/CoWSwapEip712Eip712.t.sol/TestCoWSwapEip712.json
 create mode 100644 artifacts/CoWSwapEthFlow.sol/CoWSwapEthFlow.json
 create mode 100644 artifacts/CoWSwapEthFlow.t.sol/EthFlowTestSetup.json
 create mode 100644 artifacts/CoWSwapEthFlow.t.sol/OrderDeletion.json
 create mode 100644 artifacts/CoWSwapEthFlow.t.sol/SignatureVerification.json
 create mode 100644 artifacts/CoWSwapEthFlow.t.sol/TestDeployment.json
 create mode 100644 artifacts/CoWSwapEthFlow.t.sol/TestOrderCreation.json
 create mode 100644 artifacts/CoWSwapEthFlowExposed.sol/CoWSwapEthFlowExposed.json
 create mode 100644 artifacts/CoWSwapOnchainOrders.sol/CoWSwapOnchainOrders.json
 create mode 100644 artifacts/CoWSwapOnchainOrders.t.sol/TestCoWSwapOnchainOrders.json
 create mode 100644 artifacts/CoWSwapOnchainOrdersExposed.sol/CoWSwapOnchainOrdersExposed.json
 create mode 100644 artifacts/Constants.sol/Constants.json
 create mode 100644 artifacts/EthFlowOrder.sol/EthFlowOrder.json
 create mode 100644 artifacts/EthFlowOrder.t.sol/TestCoWSwapOnchainOrders.json
 create mode 100644 artifacts/FillWithSameByte.sol/FillWithSameByte.json
 create mode 100644 artifacts/GPv2EIP1271.sol/EIP1271Verifier.json
 create mode 100644 artifacts/GPv2EIP1271.sol/GPv2EIP1271.json
 create mode 100644 artifacts/GPv2Order.sol/GPv2Order.json
 create mode 100644 artifacts/ICoWSwapEthFlow.sol/ICoWSwapEthFlow.json
 create mode 100644 artifacts/ICoWSwapOnchainOrders.sol/ICoWSwapOnchainOrders.json
 create mode 100644 artifacts/ICoWSwapSettlement.sol/ICoWSwapSettlement.json
 create mode 100644 artifacts/IERC20.sol/IERC20.json
 create mode 100644 artifacts/Reverter.sol/Reverter.json
 create mode 100644 artifacts/Script.sol/Script.json
 create mode 100644 artifacts/Test.sol/Test.json
 create mode 100644 artifacts/Test.sol/stdError.json
 create mode 100644 artifacts/Test.sol/stdMath.json
 create mode 100644 artifacts/Test.sol/stdStorage.json
 create mode 100644 artifacts/Vm.sol/Vm.json
 create mode 100644 artifacts/console.sol/console.json
 create mode 100644 artifacts/console2.sol/console2.json
 create mode 100644 artifacts/test.sol/DSTest.json
Enumerating objects: 63, done.
Counting objects: 100% (63/63), done.
Delta compression using up to 16 threads
Compressing objects: 100% (48/48), done.
Writing objects: 100% (62/62), 845.60 KiB | 2.01 MiB/s, done.
Total 62 (delta 30), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (30/30), completed with 1 local object.
To github.com:cowprotocol/ethflowcontract.git
 * [new tag]         main-artifacts -> main-artifacts
```
</details>

You can see the resulting tag [here](https://github.com/cowprotocol/ethflowcontract/tree/main-artifacts).