### PR TITLE
Add deployment script

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,4 +6,11 @@ solc = "0.8.16"
 optimizer = true
 optimizer_runs = 1000000
 
+[rpc_endpoints]
+env = "${NODE_URL}"
+mainnet = "https://mainnet.infura.io/v3/${INFURA_KEY}"
+rinkeby = "https://rinkeby.infura.io/v3/${INFURA_KEY}"
+goerli = "https://goerli.infura.io/v3/${INFURA_KEY}"
+gnosischain = "https://rpc.gnosischain.com"
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,25 @@ yarn install
 forge build
 ```
 
+### Deploy
+
+The ETH flow contract has a dedicated deployment script. To simulate a deployment, run:
+
+```sh
+forge script script/Deploy.sol --rpc-url "$RPC_URL" -vvvv
+```
+
+You can find a list of supported RPC URLs in `foundry.toml` under `[rpc_endpoints]`.
+
+To broadcast the deployment onchain you must also add the private key of the deployer and the broadcast flag: `--private-key "$PK" --broadcast`.
+
+You can verify a contract you deployed with the deployment script on the block explorer of the current chain with:
+
+```sh
+export ETHERSCAN_API_KEY=<your Etherscan API key> # Only needed if the default chain explorer is Etherscan
+forge script script/Deploy.sol --rpc-url "$RPC_URL" ---vvvv
+```
+
 ### Code formatting
 
 ```sh

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -13,7 +13,7 @@ contract Deploy is Script {
 
         new CoWSwapEthFlow(
             ICoWSwapSettlement(ValidatedAddress.cowSwapSettlement()),
-            IERC20(ValidatedAddress.wrappedNativeToken())
+            IWrappedNativeToken(ValidatedAddress.wrappedNativeToken())
         );
 
         vm.stopBroadcast();

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 import "./ValidatedAddress.sol";
 import "../src/CoWSwapEthFlow.sol";
 
-/// @title Deployer Sscript for the ETH Flow Contract
+/// @title Deployer Script for the ETH Flow Contract
 /// @author CoW Swap Developers.
 contract Deploy is Script {
     function run() external {

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "./ValidatedAddress.sol";
+import "../src/CoWSwapEthFlow.sol";
+
+/// @title Deployer Sscript for the ETH Flow Contract
+/// @author CoW Swap Developers.
+contract Deploy is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        new CoWSwapEthFlow(
+            ICoWSwapSettlement(ValidatedAddress.cowSwapSettlement()),
+            IERC20(ValidatedAddress.wrappedNativeToken())
+        );
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/ValidatedAddress.sol
+++ b/script/ValidatedAddress.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8;
+
+// solhint-disable reason-string
+
+import "../src/interfaces/ICoWSwapSettlement.sol";
+import "../src/libraries/CoWSwapEip712.sol";
+import "../src/vendored/IERC20.sol";
+
+/// @title Constant Address Validator
+/// @author CoW Swap Developers.
+library ValidatedAddress {
+    uint256 internal constant CHAINID_MAINNET = 1;
+    uint256 internal constant CHAINID_RINKEBY = 4;
+    uint256 internal constant CHAINID_GOERLI = 5;
+    uint256 internal constant CHAINID_GNOSISCHAIN = 100;
+
+    function cowSwapSettlement()
+        internal
+        view
+        returns (ICoWSwapSettlement settlement)
+    {
+        require(
+            (chainId() == CHAINID_MAINNET) ||
+                (chainId() == CHAINID_RINKEBY) ||
+                (chainId() == CHAINID_GOERLI) ||
+                (chainId() == CHAINID_GNOSISCHAIN),
+            "Settlement contract not available on this chain"
+        );
+        settlement = ICoWSwapSettlement(
+            0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+        );
+        require(
+            CoWSwapEip712.domainSeparator(address(settlement)) ==
+                WithDomainSeparator(address(settlement)).domainSeparator(),
+            "Bad domain separator for settlement contract"
+        );
+    }
+
+    function wrappedNativeToken()
+        internal
+        view
+        returns (address _wrappedNativeToken)
+    {
+        if (chainId() == CHAINID_MAINNET) {
+            _wrappedNativeToken = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+            require(eq(WithSymbol(_wrappedNativeToken).symbol(), "WETH"));
+        } else if (chainId() == CHAINID_RINKEBY) {
+            _wrappedNativeToken = 0xc778417E063141139Fce010982780140Aa0cD5Ab;
+            require(eq(WithSymbol(_wrappedNativeToken).symbol(), "WETH"));
+        } else if (chainId() == CHAINID_GOERLI) {
+            _wrappedNativeToken = 0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6;
+            require(eq(WithSymbol(_wrappedNativeToken).symbol(), "WETH"));
+        } else if (chainId() == CHAINID_GNOSISCHAIN) {
+            _wrappedNativeToken = 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d;
+            require(eq(WithSymbol(_wrappedNativeToken).symbol(), "WXDAI"));
+        } else {
+            revert("Wrapped native token not supported on this chain");
+        }
+    }
+
+    function chainId() private view returns (uint256 _chainId) {
+        // NOTE: Currently, the only way to get the chain ID in solidity is
+        // using assembly.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            _chainId := chainid()
+        }
+    }
+
+    function eq(string memory lhs, string memory rhs)
+        private
+        pure
+        returns (bool)
+    {
+        return keccak256(abi.encode(lhs)) == keccak256(abi.encode(rhs));
+    }
+}
+
+interface WithSymbol {
+    function symbol() external view returns (string memory);
+}
+
+interface WithDomainSeparator {
+    function domainSeparator() external view returns (bytes32);
+}


### PR DESCRIPTION
Adds a standard way to deploy a contract and verify its code on the chain's block explorer. See readme changes for details.

The main purpose of the deployment script is providing and validating the expected deployment parameters without them being user input at the time of deployment.

Deployments are non-deterministic. (Having deterministic deployments is easy with Foundry, however the wrapped token address is different on every chain, so it would be a bit of (imho) unnecessary extra work to make the contract addresses the same on every chain. 
The console output contains useful information like txhash and gas required.

I plan to replace `--rpc-url https://long.form.rinkeby.url` with `--rpc-url rinkeby` as soon as `foundry-rs/foundry/pull/3116` is released.

### Test plan

First, test dry run on all supported chains and verify that there is no error:

```sh
export INFURA_KEY=...
forge script script/Deploy.sol --rpc-url "https://mainnet.infura.io/v3/$INFURA_KEY" -vvvv
forge script script/Deploy.sol --rpc-url "https://rinkeby.infura.io/v3/$INFURA_KEY" -vvvv
forge script script/Deploy.sol --rpc-url "https://goerli.infura.io/v3/$INFURA_KEY" -vvvv
forge script script/Deploy.sol --rpc-url "https://rpc.gnosischain.com" -vvvv
```

Then, try to deploy a contract on Rinkeby:
```sh
forge script script/Deploy.sol --rpc-url "https://rinkeby.infura.io/v3/$INFURA_KEY" -vvvv --private-key "$PK" --broadcast
```

<details><summary>output</summary>

```
$ forge script script/Deploy.sol --rpc-url "https://rinkeby.infura.io/v3/$INFURA_KEY" -vvvv --private-key "$PK" --broadcast
[⠆] Compiling...
No files changed, compilation skipped
Traces:
  [1170880] Deploy::run() 
    ├─ [0] VM::startBroadcast() 
    │   └─ ← ()
    ├─ [272] GPv2Settlement::domainSeparator() [staticcall]
    │   └─ ← 0x30208afd16dc027408ef4f1724ce2b47e7a95b39820fb5910ac6708953f96ea1
    ├─ [3264] WETH9::symbol() [staticcall]
    │   └─ ← "WETH"
    ├─ [1033332] → new CoWSwapEthFlow@"0xaa88…237a"
    │   └─ ← 5047 bytes of code
    ├─ [0] VM::stopBroadcast() 
    │   └─ ← ()
    └─ ← ()


Script ran successfully.
==========================
Simulated On-chain Traces:

  [1163008] → new CoWSwapEthFlow@"0xaa88…237a"
    └─ ← 5047 bytes of code


==========================

Estimated total gas used for script: 1511910

Estimated amount required: 0.0045357300302382 ETH

==========================

###
Finding wallets for all the necessary addresses...
##
Sending transactions [0 - 0].
⠁ [00:00:00] [################################################################################################################################################################################] 1/1 txes (0.0s)
Transactions saved to: /app/ethflowcontract/broadcast/Deploy.sol/4/run-latest.json

##
Waiting for receipts.
⠉ [00:00:14] [#######################################################################################################################################################################] 1/1 receipts (0.0s)
#####
✅ Hash: 0x0b4972db4162c9418525c4e2db88cc627144ac34e960fb880544ecc5b7e7aa7f
Contract Address: 0xaa88a3b70633c9746c5d258f402dae041e7f237a
Block: 11339402
Paid: 0.003489024010467072 ETH (1163008 gas * 3.000000009 gwei)


Transactions saved to: /app/ethflowcontract/broadcast/Deploy.sol/4/run-latest.json



==========================

ONCHAIN EXECUTION COMPLETE & SUCCESSFUL. Transaction receipts written to "/app/ethflowcontract/broadcast/Deploy.sol/4/run-latest.json"

Transactions saved to: /app/ethflowcontract/broadcast/Deploy.sol/4/run-latest.json
```
</details>

Finally, try to verify the deployment:

```sh
forge script script/Deploy.sol --rpc-url "https://rinkeby.infura.io/v3/$INFURA_KEY" -vvvv --verify
```

<details><summary>output</summary>

```
$ forge script script/Deploy.sol --rpc-url "https://rinkeby.infura.io/v3/$INFURA_KEY" -vvvv --verify
[⠆] Compiling...
No files changed, compilation skipped
##
Start verification for (1) contracts

Submitting verification for [src/CoWSwapEthFlow.sol:CoWSwapEthFlow] Ok("0xaA88a3B70633c9746c5D258F402daE041e7f237A").
Submitted contract for verification:
        Response: `OK`
        GUID: `mc2szh8wpyp831nuj3n7fqnub6urx9zyfsxybp5izzuupvtbnf`
        URL:
        https://rinkeby.etherscan.io/address/KEY
Waiting for verification result...
Contract successfully verified
All (1) contracts were verified!

Transactions saved to: /app/ethflowcontract/broadcast/Deploy.sol/4/run-latest.json
```
</details>


See result [on Etherscan](https://rinkeby.etherscan.io/address/0xaa88a3b70633c9746c5d258f402dae041e7f237a#code).