### PR TITLE
Use arbitrary data instead of quoteId

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -93,8 +93,8 @@ contract CoWSwapEthFlow is
 
         // The data event field includes extra information needed to settle orders with the CoW Swap API.
         bytes memory data = abi.encodePacked(
-            order.quoteId,
-            onchainData.validTo
+            onchainData.validTo,
+            order.extraData
         );
 
         orderHash = broadcastOrder(

--- a/src/libraries/EthFlowOrder.sol
+++ b/src/libraries/EthFlowOrder.sol
@@ -38,10 +38,11 @@ library EthFlowOrder {
         uint32 validTo;
         /// @dev Flag indicating whether the order is fill-or-kill or can be filled partially.
         bool partiallyFillable;
-        /// @dev quoteId The quote id obtained from the CoW Swap API to lock in the current price. It is not directly
-        /// used by any onchain component but is part of the information emitted onchain on order creation and may be
-        /// required for an order to be automatically picked up by the CoW Swap orderbook.
-        int64 quoteId;
+        /// @dev extraData The extra data that is not directly used by any onchain component but is part of the
+        /// information emitted onchain on order creation and may be required for an order to be automatically picked up
+        /// by the CoW Swap orderbook. An example of this may be the quote id obtained from the CoW Swap API in order to
+        /// lock in the current price.
+        bytes extraData;
     }
 
     /// @dev An order that is owned by this address is an order that has not yet been assigned.
@@ -75,7 +76,7 @@ library EthFlowOrder {
         }
 
         // Note that not all fields from `order` are used in creating the corresponding CoW Swap order.
-        // For example, validTo and quoteId are ignored.
+        // For example, validTo and extraData are ignored.
         return
             GPv2Order.Data(
                 wrappedNativeToken, // IERC20 sellToken

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -167,7 +167,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             0,
             false,
-            0
+            hex""
         );
         assertEq(order.sellAmount, sellAmount);
 
@@ -187,7 +187,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toInt64(0x08)
+            FillWithSameByte.toVector(0x08, 42)
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.feeAmount, feeAmount);
@@ -226,7 +226,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toInt64(0x08)
+            FillWithSameByte.toVector(0x08, 42)
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.feeAmount, feeAmount);
@@ -245,7 +245,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
         uint256 sellAmount = 41 ether;
         uint256 feeAmount = 1 ether;
         uint32 validTo = FillWithSameByte.toUint32(0x01);
-        int64 quoteId = 1337;
+        bytes memory extraData = hex"1337";
         EthFlowOrder.Data memory order = EthFlowOrder.Data(
             IERC20(FillWithSameByte.toAddress(0x02)),
             FillWithSameByte.toAddress(0x03),
@@ -255,7 +255,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             validTo,
             true,
-            quoteId
+            extraData
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.feeAmount, feeAmount);
@@ -274,7 +274,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             executor,
             order.toCoWSwapOrder(wrappedNativeToken),
             signature,
-            abi.encodePacked(quoteId, validTo)
+            abi.encodePacked(validTo, extraData)
         );
         vm.prank(executor);
         ethFlow.createOrder{value: sellAmount + feeAmount}(order);
@@ -293,7 +293,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             validTo,
             true,
-            FillWithSameByte.toInt64(0x07)
+            FillWithSameByte.toVector(0x07, 42)
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.feeAmount, feeAmount);
@@ -327,7 +327,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
             feeAmount,
             FillWithSameByte.toUint32(0x05),
             false,
-            FillWithSameByte.toInt64(0x06)
+            FillWithSameByte.toVector(0x06, 42)
         );
         assertEq(order.sellAmount, sellAmount);
         assertEq(order.feeAmount, feeAmount);
@@ -348,7 +348,7 @@ contract OrderDeletion is EthFlowTestSetup {
             FillWithSameByte.toUint128(0x06), // using uint128 to avoid triggering multiplication overflow
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toInt64(0x08)
+            FillWithSameByte.toVector(0x08, 42)
         );
         require(
             order.validTo > block.timestamp,
@@ -624,7 +624,7 @@ contract SignatureVerification is EthFlowTestSetup {
             FillWithSameByte.toUint256(0x16),
             FillWithSameByte.toUint32(0x17),
             true,
-            FillWithSameByte.toInt64(0x18)
+            FillWithSameByte.toVector(0x18, 42)
         );
         require(
             order.validTo > block.timestamp,

--- a/test/EthFlowOrder.t.sol
+++ b/test/EthFlowOrder.t.sol
@@ -21,7 +21,7 @@ contract TestCoWSwapOnchainOrders is Test {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toInt64(0x08)
+            FillWithSameByte.toVector(0x08, 42)
         );
         IERC20 wrappedNativeToken = IERC20(FillWithSameByte.toAddress(0x42));
 
@@ -59,7 +59,7 @@ contract TestCoWSwapOnchainOrders is Test {
             FillWithSameByte.toUint256(0x06),
             FillWithSameByte.toUint32(0x07),
             true,
-            FillWithSameByte.toInt64(0x08)
+            FillWithSameByte.toVector(0x08, 42)
         );
         assertEq(ethFlowOrder.receiver, GPv2Order.RECEIVER_SAME_AS_OWNER);
 

--- a/test/FillWithSameByte.sol
+++ b/test/FillWithSameByte.sol
@@ -10,10 +10,6 @@ library FillWithSameByte {
         return bytes32(repeatByte(b, 32));
     }
 
-    function toInt64(uint8 b) public pure returns (int64) {
-        return int64(int256(repeatByte(b, 8)));
-    }
-
     function toUint32(uint8 b) public pure returns (uint32) {
         return uint32(repeatByte(b, 4));
     }
@@ -24,6 +20,17 @@ library FillWithSameByte {
 
     function toUint256(uint8 b) public pure returns (uint256) {
         return repeatByte(b, 32);
+    }
+
+    function toVector(uint8 b, uint256 times)
+        public
+        pure
+        returns (bytes memory result)
+    {
+        result = new bytes(times);
+        for (uint256 i = 0; i < times; i++) {
+            result[i] = bytes1(b);
+        }
     }
 
     function repeatByte(uint8 b, uint8 times) internal pure returns (uint256) {

--- a/test/e2e/TradingWithCoWSwap.sol
+++ b/test/e2e/TradingWithCoWSwap.sol
@@ -46,7 +46,7 @@ contract TradingWithCowSwap is DeploymentSetUp {
             feeAmount,
             31337, //validTo
             false, //partiallyFillable
-            424242 //quoteId
+            hex"424242" //extraData
         );
         assertLt(block.timestamp, order.validTo);
 
@@ -121,7 +121,7 @@ contract TradingWithCowSwap is DeploymentSetUp {
             feeAmount,
             31337, //validTo
             true, //partiallyFillable
-            424242 //quoteId
+            hex"424242" //extraData
         );
         assertLt(block.timestamp, order.validTo);
 


### PR DESCRIPTION
This is a naïve implementation of @nlordell suggestion of using more general arbitrary extra data instead of explicitly specifying `quoteId`, as in the future we might want to transmit different data to the backend from the contract (e.g. future new parameters or modified parameter types).

Unfortunately, it looks like these changes increase the gas cost of creating an order of about 800 gas:
```
╭────────────────────────────────────────────────┬─────────────────┬───────┬────────┬───────┬─────────╮
│ Function Name                                  ┆ min             ┆ avg   ┆ median ┆ max   ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ createOrder (main)                             ┆ 0               ┆ 28870 ┆ 35066  ┆ 35066 ┆ 23      │
│ createOrder (this PR)                          ┆ 0               ┆ 29520 ┆ 35823  ┆ 35823 ┆ 23      │
│ (diff)                                         ┆ 0               ┆ +650  ┆ +757   ┆ +757  ┆ -       │
╰────────────────────────────────────────────────┴─────────────────┴───────┴────────┴───────┴─────────╯
```

Considering that the ETH flow contract is easily replaceable in case we change the format of our backend, my preference goes against these changes, even if I consider using `extraData` cleaner and easier in terms of making the code understandable.


CC @josojo.