### PR TITLE
Empty call to WETH instead of deposit

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -62,7 +62,15 @@ contract CoWSwapEthFlow is
 
     /// @inheritdoc ICoWSwapEthFlow
     function wrap(uint256 amount) public {
-        wrappedNativeToken.deposit{value: amount}();
+        // The fallback implementation of the standard WETH9 contract just calls `deposit`. Using the fallback instead
+        // of directly calling `deposit` is slightly cheaper in terms of gas.
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, ) = payable(address(wrappedNativeToken)).call{
+            value: amount
+        }("");
+        // The success value is intentionally disregarded because depositing native tokens with the standard WETH9
+        // contract cannot revert.
+        success;
     }
 
     /// @inheritdoc ICoWSwapEthFlow

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -702,7 +702,7 @@ contract WrapUnwrap is EthFlowTestSetup {
         mockAndExpectCall(
             address(wrappedNativeToken),
             wrapAmount,
-            abi.encodeCall(IWrappedNativeToken.deposit, ()),
+            hex"",
             hex""
         );
         ethFlow.wrapAll();
@@ -714,7 +714,7 @@ contract WrapUnwrap is EthFlowTestSetup {
         mockAndExpectCall(
             address(wrappedNativeToken),
             wrapAmount,
-            abi.encodeCall(IWrappedNativeToken.deposit, ()),
+            hex"",
             hex""
         );
         ethFlow.wrap(wrapAmount);


### PR DESCRIPTION
Slightly improves the gas efficiency of calling `wrap` and `wrapAll` by up to 400 gas.

The main drawback I see is that it assumes the implementation of the wrapped native token to behave like `WETH9`.

### Test plan

Modified tests.

<details><summary>Cost comparison with `main` based on the output of diffing `forge test --gas-report`</summary>

```diff
14c14
< │ settle                  ┆ 13557           ┆ 46122 ┆ 26517  ┆ 112410 ┆ 8       │
---
> │ settle                  ┆ 13557           ┆ 46034 ┆ 26517  ┆ 112096 ┆ 8       │
49c49
< │ 1202115                                        ┆ 6610            ┆       ┆        ┆       ┆         │
---
> │ 1200109                                        ┆ 6600            ┆       ┆        ┆       ┆         │
61c61
< │ wrapAll                                        ┆ 29260           ┆ 31510 ┆ 31510  ┆ 33760 ┆ 2       │
---
> │ wrapAll                                        ┆ 28868           ┆ 31118 ┆ 31118  ┆ 33368 ┆ 2       │
87c87
< │ 1193071                                                                      ┆ 6699            ┆       ┆        ┆        ┆         │
---
> │ 1191071                                                                      ┆ 6689            ┆       ┆        ┆        ┆         │
105c105
< │ wrap                                                                         ┆ 9811            ┆ 9811  ┆ 9811   ┆ 9811   ┆ 1       │
---
> │ wrap                                                                         ┆ 9662            ┆ 9662  ┆ 9662   ┆ 9662   ┆ 1       │
107c107
< │ wrapAll                                                                      ┆ 9764            ┆ 9764  ┆ 9764   ┆ 9764   ┆ 1       │
---
> │ wrapAll                                                                      ┆ 9615            ┆ 9615  ┆ 9615   ┆ 9615   ┆ 1       │
```
</details>