### PR TITLE
Not allowing zero sell amount orders

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -86,6 +86,10 @@ contract CoWSwapEthFlow is
             revert IncorrectEthAmount();
         }
 
+        if (0 == order.sellAmount) {
+            revert NotAllowedZeroSellAmount();
+        }
+
         EthFlowOrder.OnchainData memory onchainData = EthFlowOrder.OnchainData(
             msg.sender,
             order.validTo

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -13,6 +13,9 @@ interface ICoWSwapEthFlow {
     /// @dev Error thrown when trying to create an order without sending the expected amount of ETH to this contract.
     error IncorrectEthAmount();
 
+    /// @dev Error thrown when trying to create an order with a sell amount == 0
+    error NotAllowedZeroSellAmount();
+
     /// @dev Error thrown if trying to delete an order while not allowed.
     error NotAllowedToDeleteOrder(bytes32 orderHash);
 

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -192,7 +192,7 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
         assertEq(order.sellAmount, sellAmount);
 
         vm.expectRevert(ICoWSwapEthFlow.NotAllowedZeroSellAmount.selector);
-        ethFlow.createOrder{value: sellAmount + feeAmount }(order);
+        ethFlow.createOrder{value: sellAmount + feeAmount}(order);
     }
 
     function testRevertIfCreatingAnOrderWithTheSameHashTwice() public {

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -175,6 +175,26 @@ contract TestOrderCreation is EthFlowTestSetup, ICoWSwapOnchainOrders {
         ethFlow.createOrder{value: sellAmount + feeAmount - 1}(order);
     }
 
+    function testRevertOrderCreationIfSellAmountIsZero() public {
+        uint256 sellAmount = 0 ether;
+        uint256 feeAmount = 1 ether;
+        EthFlowOrder.Data memory order = EthFlowOrder.Data(
+            IERC20(address(0)),
+            address(0),
+            sellAmount,
+            0,
+            bytes32(0),
+            feeAmount,
+            0,
+            false,
+            0
+        );
+        assertEq(order.sellAmount, sellAmount);
+
+        vm.expectRevert(ICoWSwapEthFlow.NotAllowedZeroSellAmount.selector);
+        ethFlow.createOrder{value: sellAmount + feeAmount }(order);
+    }
+
     function testRevertIfCreatingAnOrderWithTheSameHashTwice() public {
         uint256 sellAmount = 41 ether;
         uint256 feeAmount = 1 ether;


### PR DESCRIPTION
Adam is such a good auditor! 
https://cowservices.slack.com/archives/CM1HPMCE5/p1663959018673759?thread_ts=1662553939.402079&cid=CM1HPMCE5

>Unless I have missed something, I think it's possible to submit an order that has: sellAmount == 0, buyAmount == 0, feeAmount > 0 and partiallyFillable == false . This order will be executable unlimited number of times and each time it will drain feeAmount from the contract. (edited) 

This PR prevents zero sell amount orders. Even if the settlement contract would prevent 0 amounts for sell orders, we should have excluded it in the ethflow contract to be secure. 