### PR TITLE
Fix failed wrapping comment

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -66,8 +66,9 @@ contract CoWSwapEthFlow is
         (bool success, ) = payable(address(wrappedNativeToken)).call{
             value: amount
         }("");
-        // The success value is intentionally disregarded because depositing native tokens with the standard WETH9
-        // contract cannot revert.
+        // The success value is intentionally disregarded. The callback of the standard WETH9 contract has no revert
+        // path in the code, so it could only revert if the internal call runs out of gas. This is not considered a
+        // security risk since a reverting internal call would just mean that calling this function has no effect.
         success;
     }
 


### PR DESCRIPTION
Fixes an incorrect comment in the contract. Found during the contract audit by Adam.

> I think the child call can fail due to out of gas exception, while the parent call succeeds due to the fact that not all remaining gas is passed to the child call. I don’t think this presents a security problem, but the assumption is incorrect.

This means that there might be an amount of gas that can be used to call `wrap` so that the call succeeds but the internal call reverts. This is not an issue in the context of pre-interactions, as the function will be called very early in the execution of `settle` and will then have a large quantity of gas forwarded for its execution (as it's needed to execute the rest of the code in `settle`).
FYI, adding a revert in case of failure costs 29 extra gas, so considering our use case I still think it's worth the small risk of unexpected behavior if called outside of `settle` (success without wrapping).