### PR TITLE
Introducing the ability to delete many

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,8 +122,10 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray) external {
-        for (uint i=0; i<orderArray.length; i++){
+    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray)
+        external
+    {
+        for (uint256 i = 0; i < orderArray.length; i++) {
             deleteOrder(orderArray[i]);
         }
     }

--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,7 +122,7 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray)
+    function deleteOrders(EthFlowOrder.Data[] calldata orderArray)
         external
     {
         for (uint256 i = 0; i < orderArray.length; i++) {
@@ -130,10 +130,7 @@ contract CoWSwapEthFlow is
         }
     }
 
-    /// @dev Marks an existing ETH flow order as invalid and refunds the trader of all ETH that hasn't been traded yet.
-    /// Note that some parameters of the order are ignored, as for example the order expiration date and the quote id.
-    ///
-    /// @param order The order to be deleted.
+    /// @inheritdoc ICoWSwapEthFlow
     function deleteOrder(EthFlowOrder.Data calldata order) public {
         GPv2Order.Data memory cowSwapOrder = order.toCoWSwapOrder(
             wrappedNativeToken

--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,7 +122,17 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteOrder(EthFlowOrder.Data calldata order) external {
+    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray) external {
+        for (uint i=0; i<orderArray.length; i++){
+            deleteOrder(orderArray[i]);
+        }
+    }
+
+    /// @dev Marks an existing ETH flow order as invalid and refunds the trader of all ETH that hasn't been traded yet.
+    /// Note that some parameters of the order are ignored, as for example the order expiration date and the quote id.
+    ///
+    /// @param order The order to be deleted.
+    function deleteOrder(EthFlowOrder.Data calldata order) public {
         GPv2Order.Data memory cowSwapOrder = order.toCoWSwapOrder(
             wrappedNativeToken
         );

--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,9 +122,7 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteOrders(EthFlowOrder.Data[] calldata orderArray)
-        external
-    {
+    function deleteOrders(EthFlowOrder.Data[] calldata orderArray) external {
         for (uint256 i = 0; i < orderArray.length; i++) {
             deleteOrder(orderArray[i]);
         }

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -33,11 +33,11 @@ interface ICoWSwapEthFlow {
         payable
         returns (bytes32 orderHash);
 
-    /// @dev Marks an existing ETH flow order as invalid and refunds the trader of all ETH that hasn't been traded yet.
-    /// Note that some parameters of the order are ignored, as for example the order expiration date and the quote id.
+    /// @dev Marks existing ETH flow orders as invalid and refunds the trader of all ETH that hasn't been traded yet.
+    /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
-    /// @param order The order to be deleted.
-    function deleteOrder(EthFlowOrder.Data calldata order) external;
+    /// @param orderArray Array of orders to be deleted.
+    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray) external;
 
     /// @dev EIP1271-compliant onchain signature verification function.
     /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -43,7 +43,7 @@ interface ICoWSwapEthFlow {
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param order order to be deleted.
-    function deleteOrder(EthFlowOrder.Data calldata order) external ;
+    function deleteOrder(EthFlowOrder.Data calldata order) external;
 
     /// @dev EIP1271-compliant onchain signature verification function.
     /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -33,11 +33,17 @@ interface ICoWSwapEthFlow {
         payable
         returns (bytes32 orderHash);
 
-    /// @dev Marks existing ETH flow orders as invalid and refunds the trader of all ETH that hasn't been traded yet.
+    /// @dev Marks existing ETH-flow orders as invalid and refunds the ETH from the order that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param orderArray Array of orders to be deleted.
-    function deleteManyOrders(EthFlowOrder.Data[] calldata orderArray) external;
+    function deleteOrders(EthFlowOrder.Data[] calldata orderArray) external;
+
+    /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH from the order that hasn't been traded yet.
+    /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
+    ///
+    /// @param order order to be deleted.
+    function deleteOrder(EthFlowOrder.Data calldata order) external ;
 
     /// @dev EIP1271-compliant onchain signature verification function.
     /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -33,13 +33,13 @@ interface ICoWSwapEthFlow {
         payable
         returns (bytes32 orderHash);
 
-    /// @dev Marks existing ETH-flow orders as invalid and refunds the ETH from the order that hasn't been traded yet.
+    /// @dev Marks existing ETH-flow orders as invalid and, for each order, refunds the ETH that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param orderArray Array of orders to be deleted.
     function deleteOrders(EthFlowOrder.Data[] calldata orderArray) external;
 
-    /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH from the order that hasn't been traded yet.
+    /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param order order to be deleted.

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -416,7 +416,7 @@ contract OrderDeletion is EthFlowTestSetup {
         ethFlow.deleteOrder(order.data);
     }
 
-    function testCanDeleteManyOrders() public {
+    function testCanDeleteOrders() public {
         address owner = address(0x424242);
         address executor = address(0x1337);
         EthFlowOrder.Data[] memory orderArray = new EthFlowOrder.Data[](2);
@@ -433,7 +433,15 @@ contract OrderDeletion is EthFlowTestSetup {
         mockOrderFilledAmount(order2.orderUid, 0);
 
         vm.prank(executor);
-        ethFlow.deleteManyOrders(orderArray);
+        ethFlow.deleteOrders(orderArray);
+        assertEq(
+            ordersMapping(order1.hash).owner,
+            EthFlowOrder.INVALIDATED_OWNER
+        );
+        assertEq(
+            ordersMapping(order2.hash).owner,
+            EthFlowOrder.INVALIDATED_OWNER
+        );
     }
 
     function testCannotDeleteValidOrdersIfNotOwner() public {

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -420,14 +420,14 @@ contract OrderDeletion is EthFlowTestSetup {
         address owner = address(0x424242);
         address executor = address(0x1337);
         EthFlowOrder.Data[] memory orderArray = new EthFlowOrder.Data[](2);
-        orderArray[0]= dummyOrder();
+        orderArray[0] = dummyOrder();
         orderArray[0].validTo = uint32(block.timestamp) - 1;
         OrderDetails memory order_1 = orderDetails(orderArray[0]);
         mockOrderFilledAmount(order_1.orderUid, 0);
         createOrderWithOwner(order_1, owner);
         orderArray[1] = dummyOrder();
-        orderArray[1].validTo = uint32(block.timestamp) -1;
-        orderArray[1].sellAmount = orderArray[1].sellAmount+1;
+        orderArray[1].validTo = uint32(block.timestamp) - 1;
+        orderArray[1].sellAmount = orderArray[1].sellAmount + 1;
         OrderDetails memory order_2 = orderDetails(orderArray[1]);
         createOrderWithOwner(order_2, owner);
         mockOrderFilledAmount(order_2.orderUid, 0);

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -416,6 +416,26 @@ contract OrderDeletion is EthFlowTestSetup {
         ethFlow.deleteOrder(order.data);
     }
 
+    function testCanDeleteManyOrders() public {
+        address owner = address(0x424242);
+        address executor = address(0x1337);
+        EthFlowOrder.Data[] memory orderArray = new EthFlowOrder.Data[](2);
+        orderArray[0]= dummyOrder();
+        orderArray[0].validTo = uint32(block.timestamp) - 1;
+        OrderDetails memory order_1 = orderDetails(orderArray[0]);
+        mockOrderFilledAmount(order_1.orderUid, 0);
+        createOrderWithOwner(order_1, owner);
+        orderArray[1] = dummyOrder();
+        orderArray[1].validTo = uint32(block.timestamp) -1;
+        orderArray[1].sellAmount = orderArray[1].sellAmount+1;
+        OrderDetails memory order_2 = orderDetails(orderArray[1]);
+        createOrderWithOwner(order_2, owner);
+        mockOrderFilledAmount(order_2.orderUid, 0);
+
+        vm.prank(executor);
+        ethFlow.deleteManyOrders(orderArray);
+    }
+
     function testCannotDeleteValidOrdersIfNotOwner() public {
         address owner = address(0x424242);
         address executor = address(0x1337);

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -422,15 +422,15 @@ contract OrderDeletion is EthFlowTestSetup {
         EthFlowOrder.Data[] memory orderArray = new EthFlowOrder.Data[](2);
         orderArray[0] = dummyOrder();
         orderArray[0].validTo = uint32(block.timestamp) - 1;
-        OrderDetails memory order_1 = orderDetails(orderArray[0]);
-        mockOrderFilledAmount(order_1.orderUid, 0);
-        createOrderWithOwner(order_1, owner);
+        OrderDetails memory order1 = orderDetails(orderArray[0]);
+        mockOrderFilledAmount(order1.orderUid, 0);
+        createOrderWithOwner(order1, owner);
         orderArray[1] = dummyOrder();
         orderArray[1].validTo = uint32(block.timestamp) - 1;
         orderArray[1].sellAmount = orderArray[1].sellAmount + 1;
-        OrderDetails memory order_2 = orderDetails(orderArray[1]);
-        createOrderWithOwner(order_2, owner);
-        mockOrderFilledAmount(order_2.orderUid, 0);
+        OrderDetails memory order2 = orderDetails(orderArray[1]);
+        createOrderWithOwner(order2, owner);
+        mockOrderFilledAmount(order2.orderUid, 0);
 
         vm.prank(executor);
         ethFlow.deleteManyOrders(orderArray);


### PR DESCRIPTION
Just another function that allows to delete many orders at the same time by calling the existing function. This is handy for the refunder service in the backend to deal with less txs and to save some gas. 

(Same could also be archived by multi-call contracts, but I think its easier and more gas efficient if it is in the contract directly)
