### PR TITLE
deleteOrders should not revert if deletion is not successful

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,7 +122,9 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteOrders(EthFlowOrder.Data[] calldata orderArray) external {
+    function deleteOrdersIgnoringInvalid(
+        EthFlowOrder.Data[] calldata orderArray
+    ) external {
         for (uint256 i = 0; i < orderArray.length; i++) {
             _deleteOrder(orderArray[i], false);
         }
@@ -133,8 +135,9 @@ contract CoWSwapEthFlow is
         _deleteOrder(order, true);
     }
 
-    /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH that hasn't been traded yet.
-    /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
+    /// @dev Performs the same tasks as `deleteOrder` (see documentation in `ICoWSwapEthFlow`), but also allows the
+    /// caller to ignore the revert condition `NotAllowedToDeleteOrder`. Instead of reverting, it stops execution
+    /// without causing any state change.
     ///
     /// @param order order to be deleted.
     /// @param revertOnInvalidDeletion controls whether the function call should revert or just return.

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -34,10 +34,13 @@ interface ICoWSwapEthFlow {
         returns (bytes32 orderHash);
 
     /// @dev Marks existing ETH-flow orders as invalid and, for each order, refunds the ETH that hasn't been traded yet.
+    /// The function call will not revert, if some orders are not refundable. It will silently ignore these orders.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param orderArray Array of orders to be deleted.
-    function deleteOrders(EthFlowOrder.Data[] calldata orderArray) external;
+    function deleteOrdersIgnoringInvalid(
+        EthFlowOrder.Data[] calldata orderArray
+    ) external;
 
     /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -442,18 +442,18 @@ contract OrderDeletion is EthFlowTestSetup {
             ordersMapping(order2.hash).owner,
             EthFlowOrder.INVALIDATED_OWNER
         );
-        EthFlowOrder.Data[] memory orderArray_2 = new EthFlowOrder.Data[](3);
-        orderArray_2[0] = orderArray[0];
-        orderArray_2[1] = orderArray[1];
+        EthFlowOrder.Data[] memory orderArray2 = new EthFlowOrder.Data[](3);
+        orderArray2[0] = orderArray[0];
+        orderArray2[1] = orderArray[1];
         // And we can even delete the order, if some deletions are
         // already done
-        orderArray_2[2] = dummyOrder();
-        orderArray_2[2].validTo = uint32(block.timestamp) - 1;
-        orderArray_2[2].sellAmount = FillWithSameByte.toUint128(0x11);
-        OrderDetails memory order3 = orderDetails(orderArray_2[2]);
+        orderArray2[2] = dummyOrder();
+        orderArray2[2].validTo = uint32(block.timestamp) - 1;
+        orderArray2[2].sellAmount = FillWithSameByte.toUint128(0x11);
+        OrderDetails memory order3 = orderDetails(orderArray2[2]);
         createOrderWithOwner(order3, owner);
         mockOrderFilledAmount(order3.orderUid, 0);
-        ethFlow.deleteOrders(orderArray_2);
+        ethFlow.deleteOrders(orderArray2);
         assertEq(
             ordersMapping(order3.hash).owner,
             EthFlowOrder.INVALIDATED_OWNER

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -416,7 +416,7 @@ contract OrderDeletion is EthFlowTestSetup {
         ethFlow.deleteOrder(order.data);
     }
 
-    function testCanDeleteOrders() public {
+    function testCandeleteOrdersIgnoringInvalid() public {
         address owner = address(0x424242);
         address executor = address(0x1337);
         EthFlowOrder.Data[] memory orderArray = new EthFlowOrder.Data[](2);
@@ -433,7 +433,7 @@ contract OrderDeletion is EthFlowTestSetup {
         mockOrderFilledAmount(order2.orderUid, 0);
 
         vm.prank(executor);
-        ethFlow.deleteOrders(orderArray);
+        ethFlow.deleteOrdersIgnoringInvalid(orderArray);
         assertEq(
             ordersMapping(order1.hash).owner,
             EthFlowOrder.INVALIDATED_OWNER
@@ -453,7 +453,7 @@ contract OrderDeletion is EthFlowTestSetup {
         OrderDetails memory order3 = orderDetails(orderArray2[2]);
         createOrderWithOwner(order3, owner);
         mockOrderFilledAmount(order3.orderUid, 0);
-        ethFlow.deleteOrders(orderArray2);
+        ethFlow.deleteOrdersIgnoringInvalid(orderArray2);
         assertEq(
             ordersMapping(order3.hash).owner,
             EthFlowOrder.INVALIDATED_OWNER

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -442,6 +442,22 @@ contract OrderDeletion is EthFlowTestSetup {
             ordersMapping(order2.hash).owner,
             EthFlowOrder.INVALIDATED_OWNER
         );
+        EthFlowOrder.Data[] memory orderArray_2 = new EthFlowOrder.Data[](3);
+        orderArray_2[0] = orderArray[0];
+        orderArray_2[1] = orderArray[1];
+        // And we can even delete the order, if some deletions are
+        // already done
+        orderArray_2[2] = dummyOrder();
+        orderArray_2[2].validTo = uint32(block.timestamp) - 1;
+        orderArray_2[2].sellAmount = FillWithSameByte.toUint128(0x11);
+        OrderDetails memory order3 = orderDetails(orderArray_2[2]);
+        createOrderWithOwner(order3, owner);
+        mockOrderFilledAmount(order3.orderUid, 0);
+        ethFlow.deleteOrders(orderArray_2);
+        assertEq(
+            ordersMapping(order3.hash).owner,
+            EthFlowOrder.INVALIDATED_OWNER
+        );
     }
 
     function testCannotDeleteValidOrdersIfNotOwner() public {


### PR DESCRIPTION
Similar to @fedgiac  suggestion on the previous [PR](https://github.com/cowprotocol/ethflowcontract/pull/29).
I think this change is okay as:

- the change in the audited code is minimal
- the gas overhead is minimal < 200 gas.

- I did not expose the flag `revertOnInvalidDeletion` as its not interesting for most users. Advanced users can still use this feature by calling `deleteOrders` instead of `deleteOrder`

Tests:
unit tests only.