### PR TITLE
Automatically generate networks.json

### DIFF
--- a/.github/scripts/generate-artifacts.sh
+++ b/.github/scripts/generate-artifacts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+repo_root_dir='.'
+deployment_output_folder="$repo_root_dir/broadcast/Deploy.sol"
+
+echo "Creating build artifacts..."
+forge build -o artifacts
+
+echo "Creating networks.json..."
+for deployment in "$deployment_output_folder/"*; do
+  # The subfolder name is the chain id
+  chain_id=${deployment##*/}
+  # First, every single deployment is formatted as if it had its own networks.json
+  jq --arg chainId "$chain_id" '
+    .transactions[]
+    | select(.transactionType == "CREATE" )
+    | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
+  '  <"$deployment/deployment.json"
+  # Then, all these single-contract single-chain-id networks.jsons are merged
+done \
+  | jq -n 'reduce inputs as $item ({}; . *= $item)' \
+  > "$repo_root_dir/networks.json"

--- a/.github/scripts/generate-artifacts.sh
+++ b/.github/scripts/generate-artifacts.sh
@@ -21,6 +21,7 @@ for deployment in "$deployment_output_folder/"*; do
     | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
   '  <"$deployment/deployment.json"
 done \
-  | # Then, all these single-contract single-chain-id networks.jsons are merged
+  | # Then, all these single-contract single-chain-id networks.jsons are merged. Note: in case the same contract is
+    # deployed twice in the same script run, the last deployed contract takes priority.  
     jq -n 'reduce inputs as $item ({}; . *= $item)' \
   > "$repo_root_dir/networks.json"

--- a/.github/scripts/generate-artifacts.sh
+++ b/.github/scripts/generate-artifacts.sh
@@ -20,7 +20,7 @@ for deployment in "$deployment_output_folder/"*; do
     | select(.transactionType == "CREATE" )
     | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
   '  <"$deployment/deployment.json"
-  # Then, all these single-contract single-chain-id networks.jsons are merged
 done \
-  | jq -n 'reduce inputs as $item ({}; . *= $item)' \
+  | # Then, all these single-contract single-chain-id networks.jsons are merged
+    jq -n 'reduce inputs as $item ({}; . *= $item)' \
   > "$repo_root_dir/networks.json"

--- a/.github/scripts/release-artifacts.sh
+++ b/.github/scripts/release-artifacts.sh
@@ -8,6 +8,7 @@ set -o pipefail
 set -o errexit
 
 main_branch="main"
+script_path=$(dirname "$0")
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <refs/tags/tag-name or 'refs/heads/$main_branch'>"
@@ -34,9 +35,9 @@ artifacts_tag="$target_ref_short-artifacts"
 git fetch origin "$target_ref"
 git checkout --detach "$target_ref"
 
-forge build -o artifacts
+bash "$script_path/generate-artifacts.sh"
 
-git add artifacts
+git add --all
 git commit -m "Add artifacts for $target_ref"
 git tag -m "Artifacts for $target_ref" --end-of-options "$artifacts_tag"
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,4 +25,4 @@ jobs:
           version: nightly
 
       - name: Generate artifacts and push as new tag
-        run: bash .github/scripts/artifacts.sh "$GITHUB_REF"
+        run: bash .github/scripts/release-artifacts.sh "$GITHUB_REF"


### PR DESCRIPTION
Closes #26.

Inspired by [this comment](https://github.com/cowprotocol/ethflowcontract/pull/26#pullrequestreview-1113701155), it generates `networks.json` based on the content of our `broadcast` folder. When we manually deploy the contract we still need to commit the content of `broadcast`, however the file `networks.json` will be automatically generated along with the artifacts with our release script.

Unfortunately I don't think it's possible to generate `networks.json` in the deployment script: the main issue is that the transaction id isn't available inside the script. Otherwise, Foundry allows you to read from and write to files, as well as some basic JSON parsing (but not encoding).

### Test plan

Release a new tag under this commit and see the output.
[Here](https://github.com/cowprotocol/ethflowcontract/actions/runs/3347321333/jobs/5545176777#step:4:83) is the output of the GitHub action, [here](https://github.com/cowprotocol/ethflowcontract/commit/9dfdc62418670e49e574e1a2b19107ff75c75f48) is the new commit, and [here](https://github.com/cowprotocol/ethflowcontract/blob/9dfdc62418670e49e574e1a2b19107ff75c75f48/networks.json) is `networks.json`.