### PR TITLE
Add order deletion event

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -178,7 +178,7 @@ contract CoWSwapEthFlow is
         // solhint-disable-next-line not-rely-on-time
         if (isTradable) {
             // Order is valid but its owner decided to delete it.
-            emit OrderDeletion(orderUid);
+            emit OrderInvalidation(orderUid);
         } else {
             // The order cannot be traded anymore, so this transaction is likely triggered to get back the ETH. We are
             // interested in knowing who is the source of the refund.

--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -174,6 +174,9 @@ contract CoWSwapEthFlow is
             address(this),
             cowSwapOrder.validTo
         );
+
+        emit OrderDeletion(orderUid);
+
         uint256 filledAmount = cowSwapSettlement.filledAmount(orderUid);
 
         // This comment argues that a CoW Swap trader does not pay more fees if a partially fillable order is

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -3,9 +3,21 @@ pragma solidity ^0.8;
 
 import "../libraries/EthFlowOrder.sol";
 
+/// @title CoW Swap ETH Flow Event Interface
+/// @author CoW Swap Developers
+interface ICoWSwapEthFlowEvents {
+    /// @dev Event emitted to notify that an order was refunded. Note that this event is not fired if the order is
+    /// cancelled (even though the user receives all unspent ETH back). This is because we want to differenciate the
+    /// case where the user cancels a valid order and when the user receives back the funds from an expired order.
+    ///
+    /// @param orderUid CoW Swap's unique order identifier of the order that has been cancelled.
+    /// @param refunder The address that triggered the order refund.
+    event OrderRefund(bytes indexed orderUid, address indexed refunder);
+}
+
 /// @title CoW Swap ETH Flow Interface
 /// @author CoW Swap Developers
-interface ICoWSwapEthFlow {
+interface ICoWSwapEthFlow is ICoWSwapEthFlowEvents {
     /// @dev Error thrown when trying to create a new order whose order hash is the same as an order hash that was
     /// already assigned.
     error OrderIsAlreadyOwned(bytes32 orderHash);

--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -46,5 +46,5 @@ interface ICoWSwapOnchainOrders {
     /// @dev Event emitted to notify that an order was deleted.
     ///
     /// @param orderUid CoW Swap's unique order identifier of the order that has been cancelled.
-    event OrderDeletion(bytes indexed orderUid);
+    event OrderInvalidation(bytes indexed orderUid);
 }

--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -42,4 +42,9 @@ interface ICoWSwapOnchainOrders {
         OnchainSignature signature,
         bytes data
     );
+
+    /// @dev Event emitted to notify that an order was deleted.
+    ///
+    /// @param orderUid CoW Swap's unique order identifier of the order that has been cancelled.
+    event OrderDeletion(bytes indexed orderUid);
 }

--- a/test/CoWSwapEthFlow.t.sol
+++ b/test/CoWSwapEthFlow.t.sol
@@ -489,7 +489,7 @@ contract OrderDeletion is
         mockOrderFilledAmount(order.orderUid, 0);
 
         vm.expectEmit(true, true, true, true, address(ethFlow));
-        emit ICoWSwapOnchainOrders.OrderDeletion(order.orderUid);
+        emit ICoWSwapOnchainOrders.OrderInvalidation(order.orderUid);
 
         vm.prank(owner);
         ethFlow.deleteOrder(order.data);


### PR DESCRIPTION
Adds an event that is emitted to notify that an order has been cancelled.

Related to https://github.com/cowprotocol/services/issues/708, there is a need to know about order cancellations quickly (for example, for presenting information to the user that is as updated as possible). The easiest way by far is emitting an event that can be listened to from the node, at the price of some gas overhead when deleting an order.

(About `OrderDeletion`) Concretely, emitting this event requires extra ~1500 gas.
Very surprisingly, if the event were _not_ indexed, then it would cost ~2160 extra gas instead, which is why the event is indexed. I imagine this might be because of some unnecessary memory reallocation when creating the (trivially) combined logged data, which isn't present if the entry is standalone part of the log. (It looks like the issue can be replicated for a contract that just emits the same event in Remix, so it's not a problem of our tooling. Looking at the memory usage of the function, it actually seems like it writes to memory one less time.)
Trimming out the `indexed` and emitting the event from assembly should net us 375 gas (from yellow paper, cost of `Glogtopic`). 

(About `OrderRefund`.) `orderUid` needs to be indexed. We could save ~100 gas by not making the `refunder` parameter indexed, but it might be handy to have it indexed for our usage. 

### Test plan

New unit test.