### PR TITLE
Use "invalidate" instead of delete/cancel

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -122,26 +122,26 @@ contract CoWSwapEthFlow is
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteOrdersIgnoringInvalid(
+    function invalidateOrdersIgnoringNotAllowed(
         EthFlowOrder.Data[] calldata orderArray
     ) external {
         for (uint256 i = 0; i < orderArray.length; i++) {
-            _deleteOrder(orderArray[i], false);
+            _invalidateOrder(orderArray[i], false);
         }
     }
 
     /// @inheritdoc ICoWSwapEthFlow
-    function deleteOrder(EthFlowOrder.Data calldata order) public {
-        _deleteOrder(order, true);
+    function invalidateOrder(EthFlowOrder.Data calldata order) public {
+        _invalidateOrder(order, true);
     }
 
-    /// @dev Performs the same tasks as `deleteOrder` (see documentation in `ICoWSwapEthFlow`), but also allows the
-    /// caller to ignore the revert condition `NotAllowedToDeleteOrder`. Instead of reverting, it stops execution
+    /// @dev Performs the same tasks as `invalidateOrder` (see documentation in `ICoWSwapEthFlow`), but also allows the
+    /// caller to ignore the revert condition `NotAllowedToInvalidateOrder`. Instead of reverting, it stops execution
     /// without causing any state change.
     ///
-    /// @param order order to be deleted.
+    /// @param order order to be invalidated.
     /// @param revertOnInvalidDeletion controls whether the function call should revert or just return.
-    function _deleteOrder(
+    function _invalidateOrder(
         EthFlowOrder.Data calldata order,
         bool revertOnInvalidDeletion
     ) internal {
@@ -160,7 +160,7 @@ contract CoWSwapEthFlow is
             (isTradable && orderData.owner != msg.sender)
         ) {
             if (revertOnInvalidDeletion) {
-                revert NotAllowedToDeleteOrder(orderHash);
+                revert NotAllowedToInvalidateOrder(orderHash);
             } else {
                 return;
             }
@@ -177,7 +177,7 @@ contract CoWSwapEthFlow is
 
         // solhint-disable-next-line not-rely-on-time
         if (isTradable) {
-            // Order is valid but its owner decided to delete it.
+            // Order is valid but its owner decided to invalidate it.
             emit OrderInvalidation(orderUid);
         } else {
             // The order cannot be traded anymore, so this transaction is likely triggered to get back the ETH. We are

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -6,11 +6,12 @@ import "../libraries/EthFlowOrder.sol";
 /// @title CoW Swap ETH Flow Event Interface
 /// @author CoW Swap Developers
 interface ICoWSwapEthFlowEvents {
-    /// @dev Event emitted to notify that an order was refunded. Note that this event is not fired if the order is
-    /// cancelled (even though the user receives all unspent ETH back). This is because we want to differenciate the
-    /// case where the user cancels a valid order and when the user receives back the funds from an expired order.
+    /// @dev Event emitted to notify that an order was refunded. Note that this event is not fired every time the order
+    /// is invalidated (even though the user receives all unspent ETH back). This is because we want to differenciate
+    /// the case where the user invalidates a valid order and when the user receives back the funds from an expired
+    /// order.
     ///
-    /// @param orderUid CoW Swap's unique order identifier of the order that has been cancelled.
+    /// @param orderUid CoW Swap's unique order identifier of the order that has been invalidated (and refunded).
     /// @param refunder The address that triggered the order refund.
     event OrderRefund(bytes indexed orderUid, address indexed refunder);
 }
@@ -28,8 +29,8 @@ interface ICoWSwapEthFlow is ICoWSwapEthFlowEvents {
     /// @dev Error thrown when trying to create an order with a sell amount == 0
     error NotAllowedZeroSellAmount();
 
-    /// @dev Error thrown if trying to delete an order while not allowed.
-    error NotAllowedToDeleteOrder(bytes32 orderHash);
+    /// @dev Error thrown if trying to invalidate an order while not allowed.
+    error NotAllowedToInvalidateOrder(bytes32 orderHash);
 
     /// @dev Error thrown when unsuccessfully sending ETH to an address.
     error EthTransferFailed();
@@ -49,16 +50,16 @@ interface ICoWSwapEthFlow is ICoWSwapEthFlowEvents {
     /// The function call will not revert, if some orders are not refundable. It will silently ignore these orders.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
-    /// @param orderArray Array of orders to be deleted.
-    function deleteOrdersIgnoringInvalid(
+    /// @param orderArray Array of orders to be invalidated.
+    function invalidateOrdersIgnoringNotAllowed(
         EthFlowOrder.Data[] calldata orderArray
     ) external;
 
     /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
-    /// @param order order to be deleted.
-    function deleteOrder(EthFlowOrder.Data calldata order) external;
+    /// @param order Order to be invalidated.
+    function invalidateOrder(EthFlowOrder.Data calldata order) external;
 
     /// @dev EIP1271-compliant onchain signature verification function.
     /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an

--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -43,8 +43,8 @@ interface ICoWSwapOnchainOrders {
         bytes data
     );
 
-    /// @dev Event emitted to notify that an order was deleted.
+    /// @dev Event emitted to notify that an order was invalidated.
     ///
-    /// @param orderUid CoW Swap's unique order identifier of the order that has been cancelled.
+    /// @param orderUid CoW Swap's unique order identifier of the order that has been invalidated.
     event OrderInvalidation(bytes indexed orderUid);
 }

--- a/test/e2e/TradingWithCoWSwap.t.sol
+++ b/test/e2e/TradingWithCoWSwap.t.sol
@@ -101,7 +101,7 @@ contract TradingWithCowSwap is DeploymentSetUp {
     function testPartiallyFillableOrder() public {
         // Sell 100 ETH for 2M COW (plus 1 ETH fees) in a partially fillable order matching multiple times against the
         // internal buffer of the settlement contract.
-        // When the order is 80% filled, delete it.
+        // When the order is 80% filled, invalidate it.
         address user = FillWithSameByte.toAddress(0x42);
         uint256 sellAmount = 100 ether;
         uint256 buyAmount = 2000000 ether;
@@ -218,9 +218,9 @@ contract TradingWithCowSwap is DeploymentSetUp {
         );
         assertEq(address(ethFlow).balance, 0);
 
-        // Delete what remains of the order
+        // Invalidate what remains of the order
         vm.prank(user);
-        ethFlow.deleteOrder(order);
+        ethFlow.invalidateOrder(order);
         assertEq(user.balance, unusedSellAmount + returnedFeeAmount);
     }
 


### PR DESCRIPTION
Implements the suggestion from [here](https://github.com/cowprotocol/ethflowcontract/pull/33#discussion_r1014159428).

It makes the contract consistently use "invalidate" to signify that the order doesn't have a valid signature anymore and the unsettled ETH balance is refunded. This is done for consistency with the settlement contract, which uses "invalidate" to mark an order as invalid. Note however that the invalidate function from the settlement contract isn't called anywhere.

### Test plan

No actual contract changes except for different function/error/event signatures, so only existing unit tests.