### PR TITLE
Store orderUid in event data

### DIFF
--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -13,7 +13,7 @@ interface ICoWSwapEthFlowEvents {
     ///
     /// @param orderUid CoW Swap's unique order identifier of the order that has been invalidated (and refunded).
     /// @param refunder The address that triggered the order refund.
-    event OrderRefund(bytes indexed orderUid, address indexed refunder);
+    event OrderRefund(bytes orderUid, address indexed refunder);
 }
 
 /// @title CoW Swap ETH Flow Interface

--- a/src/interfaces/ICoWSwapOnchainOrders.sol
+++ b/src/interfaces/ICoWSwapOnchainOrders.sol
@@ -46,5 +46,5 @@ interface ICoWSwapOnchainOrders {
     /// @dev Event emitted to notify that an order was invalidated.
     ///
     /// @param orderUid CoW Swap's unique order identifier of the order that has been invalidated.
-    event OrderInvalidation(bytes indexed orderUid);
+    event OrderInvalidation(bytes orderUid);
 }


### PR DESCRIPTION
An event that contains an indexed parameter with a reference types (like `bytes memory`) doesn't include the full data in the event data but only the hash ([source](https://docs.soliditylang.org/en/latest/contracts.html#events)).

We are however interested in reading `orderUid` from onchain data. We do this by not indexing `orderUid`.

Some other discarded options:

1.  We could emit the order hash instead, since validity and order owner are always the same. This leads to gas savings of ~900/1100. We decided these events aren't expected to fire often, so we prefer to keep the event more generic.
2. We could keep an index for `orderUid` (e.g., `event OrderInvalidation(bytes indexed _orderUid, bytes orderUid)`). This costs ~500 gas. We decided against it because (1) it looks weird and (2) there is no concrete use case for selecting an event based on `orderUid`, since the backend will process every cancellation and show the result on the interface.

### Test plan

Existing unit tests.