### PR TITLE
Do not revert order creation if two orders with the same parameters are created by different users

### DIFF
--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -52,14 +52,18 @@ interface ICoWSwapEthFlow is ICoWSwapEthFlowEvents {
     ///
     /// @param orderArray Array of orders to be invalidated.
     function invalidateOrdersIgnoringNotAllowed(
-        EthFlowOrder.Data[] calldata orderArray
+        EthFlowOrder.Data[] calldata orderArray,
+        bytes32[] calldata providedOrderHashes
     ) external;
 
     /// @dev Marks an existing ETH-flow order as invalid and refunds the ETH that hasn't been traded yet.
     /// Note that some parameters of the orders are ignored, as for example the order expiration date and the quote id.
     ///
     /// @param order Order to be invalidated.
-    function invalidateOrder(EthFlowOrder.Data calldata order) external;
+    function invalidateOrder(
+        EthFlowOrder.Data calldata order,
+        bytes32 providedOrderHash
+    ) external;
 
     /// @dev EIP1271-compliant onchain signature verification function.
     /// This function is used by the CoW Swap settlement contract to determine if an order that is signed with an

--- a/src/libraries/EthFlowOrder.sol
+++ b/src/libraries/EthFlowOrder.sol
@@ -99,4 +99,12 @@ library EthFlowOrder {
                 GPv2Order.BALANCE_ERC20 // bytes32 buyTokenBalance
             );
     }
+
+    function hash(
+        bytes32 cowSwapOrderHash,
+        address owner,
+        uint32 validTo
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(cowSwapOrderHash, owner, validTo));
+    }
 }


### PR DESCRIPTION
One of the main usability pain points of the current smart contract is that two independent users cannot create orders with the exact same parameters. This creates race conditions on order creation between independent users and requires workarounds somewhere in our infrastructure to avoid this issue. The currently planned workaround is [this](https://github.com/cowprotocol/services/issues/804).

These changes should fix the order collision issue. The only remaining case that would cause a transaction to revert unexpectedly on creation is if the same address sends two exactly identical orders (including _real_ validity) one after another.

Drawbacks:
- We need to adapt these changes in our current work. I think most of the work would be in the backend and should be doable. For the frontend, it would change the ABI for order deletion (needs to compute an extra hash) and (if done, not sure) it changes how to get order information onchain (same extra hash).
- More expensive operations. But not too much, < 1000 gas each.
- We need to reaudit the contract. These changes very much affect the security of the whole contract.

*Note*: the PR is a draft insofar that I might improve readability and add further tests. However, the ABI and logic will stay as in this PR so it's worth discussing before spending more time improving it.

The idea behind the changes is that an eth-flow order is added the concept of a "hash" that is different from the CoW Swap one (while still depending on it). This hash includes extra order information like ownership and validity. However, it needs to be presented explicitly on both invalidation and signing, since the information needed to compute it is not part of the order. Also, this extra information needs to be verified against what is available onchain.

### Extra cost

Comparing current `main` with this PR, I notice the following differences:

|            | createOrder | isValidSignature | invalidateOrder | invalidateOrdersIgnoringNotAllowed |
|------------|-------------|------------------|-----------------|------------------------------------|
| main       |       32769 |             1560 |           48327 |                              47441 |
| this PR    |       33002 |             1962 |           48707 |                              48403 |
| difference |        +233 |             +402 |            +380 |                               +962 |

### Test plan

To do. But I already updated all existing unit tests.