### PR TITLE
Revert on order creation if order is already expired

### DIFF
--- a/src/CoWSwapEthFlow.sol
+++ b/src/CoWSwapEthFlow.sol
@@ -91,6 +91,11 @@ contract CoWSwapEthFlow is
             revert NotAllowedZeroSellAmount();
         }
 
+        // solhint-disable-next-line not-rely-on-time
+        if (order.validTo < block.timestamp) {
+            revert OrderIsAlreadyExpired();
+        }
+
         EthFlowOrder.OnchainData memory onchainData = EthFlowOrder.OnchainData(
             msg.sender,
             order.validTo

--- a/src/interfaces/ICoWSwapEthFlow.sol
+++ b/src/interfaces/ICoWSwapEthFlow.sol
@@ -23,6 +23,9 @@ interface ICoWSwapEthFlow is ICoWSwapEthFlowEvents {
     /// already assigned.
     error OrderIsAlreadyOwned(bytes32 orderHash);
 
+    /// @dev Error thrown when trying to create an order that would be expired at the time of creation
+    error OrderIsAlreadyExpired();
+
     /// @dev Error thrown when trying to create an order without sending the expected amount of ETH to this contract.
     error IncorrectEthAmount();
 


### PR DESCRIPTION
A user who creates an eth-flow order from the frontend could decide to lower the gas so much that the order is already expired at creation time. Then, the user would need to further pay ETH to cancel this order.
We decided it's a nicer user experience to revert in this case, even if it makes each order creation more expensive for standard users.

I'll shortly create a new contract release for the services, I just need to sort out how to tackle the ethcontract issue where Foundry's ABI format isn't supported.  

### Test plan

Modified and new unit tests. 
