### PR TITLE
Add hardhat build artifacts

### DIFF
--- a/.github/scripts/generate-artifacts.sh
+++ b/.github/scripts/generate-artifacts.sh
@@ -25,3 +25,8 @@ done \
     # deployed twice in the same script run, the last deployed contract takes priority.  
     jq -n 'reduce inputs as $item ({}; . *= $item)' \
   > "$repo_root_dir/networks.json"
+
+echo "Creating hardhat build artifacts..."
+# Eventually we want to stop generating Hardhat artifacts, in the meantime we pin here a specific version
+yarn add --dev "hardhat@2.12.2"
+npx hardhat --config "$repo_root_dir/.github/scripts/hardhat.config.js" compile

--- a/.github/scripts/hardhat.config.js
+++ b/.github/scripts/hardhat.config.js
@@ -1,0 +1,19 @@
+// This file is used to generate build artifacts that conform to Hardhat's format.
+module.exports = {
+  paths: {
+    root: "../../",
+    artifacts: "hardhat-artifacts/",
+    cache: "cache/hardhat/",
+    sources: "src/",
+  },
+  solidity: {
+    // Settings copied from foundry.toml
+    version: "0.8.16",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 1000000,
+      },
+    },
+  },
+};


### PR DESCRIPTION
The services currently depend on a manually built Hardhat version of the contracts ([context](https://github.com/cowprotocol/services/pull/776#discussion_r1022040961)).

This PR adds a Hardhat build to our released artifacts.
There is a lot of config duplication, but eventually I hope to remove these changes and make ethcontracts Foundry-compatible (or see [this PR](https://github.com/gnosis/ethcontract-rs/pull/863) merged), but for now it's easier to add an extra build step.

### Test plan

I already used a release based on this PR to the services, you can see CI passes [there](https://github.com/cowprotocol/services/pull/851) after the changes.

I released a tag `hardhat-test`, see its [CI logs](https://github.com/cowprotocol/ethflowcontract/actions/runs/3540272390/jobs/5943122530) and the [resulting new tag](https://github.com/cowprotocol/ethflowcontract/tree/hardhat-test-artifacts). I also tried to build the services with this test version and run the eth-flow-related e2e tests.