### PR TITLE
Add CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,23 @@
+  name: "cla"
+
+  on:
+    issue_comment:
+      types: [created]
+    pull_request_target:
+      types: [opened, closed, synchronize]
+
+  jobs:
+    cla:
+      runs-on: ubuntu-latest
+      steps:
+        - name: "CLA Assistant"
+          if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+          uses: contributor-assistant/github-action@v2.2.1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
+          with:
+            branch: 'cla-signatures'
+            path-to-signatures: 'signatures/version1/cla.json'
+            path-to-document: 'https://github.com/cowprotocol/cla/blob/main/CLA.md'
+            allowlist: '*[bot]'


### PR DESCRIPTION
Creates a CLA workflow following the instructions from [here](https://github.com/cowprotocol/cla/tree/99f858b75a108cecdf7a67ecacbccafe9e1b1da0).

- [x] Branch [cla-signatures](https://github.com/cowprotocol/ethflowcontract/tree/cla-signatures) has been created.

### (Future) test plan

CLA should be triggered in PR #48 and then be merged successfully.