### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cowprotocol/contracts


### PR DESCRIPTION
Adds code owners to this repo.
Similar to the [services](https://github.com/cowprotocol/services/blob/275723d77a116790eb0cffcd03e83e50dcf1f903/.github/CODEOWNERS), every new non-draft PR will automatically require a review from a code owner on creation.