### PR TITLE
add ability to specify settlement package information in ethflow package

### DIFF
--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -1,6 +1,15 @@
 #:schema https://raw.githubusercontent.com/usecannon/cannon/refs/heads/dev/packages/lsp/src/schema.json
 name = "cow-ethflow"
-version = "1.0.3"
+version = "1.0.4"
+
+[var.main]
+cowSettlementPkg = "cow-settlement:2.0.2"
+
+# WARNING: Make sure you override the wrappedNativeToken with the corresponding native token contract address in the network.
+# The deployment of CoWSwapEthFlow needs to happen in nonce 0, so there's only one possible attempt.
+wrappedNativeToken = "<%= dummyToken.Token.address %>"
+
+deployerAccount = "0x18AA26D5e4A18ef6E49c509D52a4f7d60242b10D"
 
 # dummy token for test network only
 [import.dummyToken]
@@ -8,16 +17,10 @@ source = "mintable-token:2.0"
 chainId = 13370
 
 [import.cow]
-source = "cow-settlement:2.0.2"
+source = "<%= settings.cowSettlementPkg %>"
 
-[var.main]
+[var.settlementData]
 cowSettlement = "<%= cow.Settlement.address %>"
-
-# WARNING: Make sure you override the wrappedNativeToken with the corresponding native token contract address in the network.
-# The deployment of CoWSwapEthFlow needs to happen in nonce 0, so there's only one possible attempt.
-wrappedNativeToken = "<%= dummyToken.Token.address %>"
-
-deployerAccount = "0x18AA26D5e4A18ef6E49c509D52a4f7d60242b10D"
 
 [deploy.EthFlow]
 artifact = "CoWSwapEthFlow"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "LGPL-3.0-or-later",
   "devDependencies": {
-    "@usecannon/cli": "2.26.0-alpha.0",
+    "@usecannon/cli": "2.26.0",
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "^1.0.0-beta.24",
     "solhint": "^3.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,10 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
-"@usecannon/builder@2.26.0-alpha.0":
-  version "2.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@usecannon/builder/-/builder-2.26.0-alpha.0.tgz#039d3d66101f6b0e2d3de8bca51c134336d79717"
-  integrity sha512-o1YUNWb6WxcKU/byMbzHfGvzYn795YQEp2aJ+dgcqidNd3p5T3cX0Q86QeDEPGoCaJgqPmACN21/iE3NvyTWhA==
+"@usecannon/builder@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@usecannon/builder/-/builder-2.26.0.tgz#43bdd02f0d9d7cc8f80a454e58e367d7daf35268"
+  integrity sha512-rzgp+CInwn9TQNaQPYUVJWly0WTeFmkxu+/nC3DoQIY+lW4bL2bDENMNwfN+aIHIUf59Yb7KGXsXoVxFiEJpfQ==
   dependencies:
     "@usecannon/router" "^4.1.3"
     "@usecannon/web-solc" "0.5.1"
@@ -394,13 +394,13 @@
     viem "^2.25.1"
     zod "^3.24.2"
 
-"@usecannon/cli@2.26.0-alpha.0":
-  version "2.26.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@usecannon/cli/-/cli-2.26.0-alpha.0.tgz#dd33d0a1268085e6ea5c619e02fe2b676d9d2d6f"
-  integrity sha512-0+OBLmW0Mc6L4VtzEm39uTNOAueIr0ntOGurx/o9zkPm/3JEaomNcLcpgO5kpdccwUaAly+sl2eoV+PejvZeig==
+"@usecannon/cli@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@usecannon/cli/-/cli-2.26.0.tgz#6391729955936d942cdae62dc78090e0a5642583"
+  integrity sha512-eGgfTcAqRZua3+vDEtatpzp71UzdIMpMJxniua0WL6tm7GllAl+XiZ21/9OI1EhuOS3TPcwAUUMqOIx4Yl+r8w==
   dependencies:
     "@iarna/toml" "^3.0.0"
-    "@usecannon/builder" "2.26.0-alpha.0"
+    "@usecannon/builder" "2.26.0"
     abitype "^1.0.8"
     chalk "^4.1.2"
     commander "^12.1.0"
@@ -2284,7 +2284,7 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.4, semver@^7.7.1:
+semver@^7.3.4, semver@^7.6.2, semver@^7.7.1:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -2686,6 +2686,13 @@ viem@^2.25.1:
     isows "1.0.7"
     ox "0.12.4"
     ws "8.18.3"
+
+web-solc@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/web-solc/-/web-solc-0.5.1.tgz#2f257550323236aa8f81cc7f171fdd7393d8d6cd"
+  integrity sha512-Z/hBplZq1+4i4bYeIeD9N3vP1BLUBXpSDa4h0Ipm2Z2cHv7x7DtZ2zFb0E1L1VZo4BF+OJGVtGlT+nTUXGgncQ==
+  dependencies:
+    semver "^7.6.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
In the downstream [staging env mainnet](https://github.com/cowprotocol/deployments/pull/8) PR we need to be able to override the settlement package--specifically in this case for use overriding the source preset. Otherwise, the `main` namespace settlement package needs to be deployed, and this is a problem for networks where we deploy `staging` first (or othrewise, have not yet deployed the `main` production of the settlement package)

the reason this error occurred in the first place without being caught was due to a holdover in my local cannon registry due to previous testing.